### PR TITLE
Hide on select by default

### DIFF
--- a/projects/ngds-forms/assets/styles/styles.scss
+++ b/projects/ngds-forms/assets/styles/styles.scss
@@ -12,6 +12,10 @@ $calendar-active-bg-color: #c5c5c5;
 $calendar-inactive-text-color: #c4c4c4;
 $calendar-out-of-range-color: #707070;
 
+.sublabel-text {
+  font-size: 0.9rem;
+}
+
 .disabled-input {
   background-color: $input-disabled-bg;
 }

--- a/projects/ngds-forms/src/lib/components/input-addons/ngds-input-header/ngds-input-header.component.html
+++ b/projects/ngds-forms/src/lib/components/input-addons/ngds-input-header/ngds-input-header.component.html
@@ -5,7 +5,7 @@
       <!-- Show required asterisk -->
       <span *ngIf="isRequired()" class="text-danger ms-1">*</span>
       <!-- Show sub label -->
-      <div class="fw-light text-muted">
+      <div class="fw-light text-muted sublabel-text">
         {{subLabel}}
       </div>
     </label>

--- a/projects/ngds-forms/src/lib/components/input-types/date-input/date-input.component.html
+++ b/projects/ngds-forms/src/lib/components/input-types/date-input/date-input.component.html
@@ -11,13 +11,13 @@
 
     <!-- Input display control value-->
     <button class="form-control border-0 px-3 m-0 text-start" type="button" data-bs-toggle="dropdown"
-      data-bs-auto-close="outside" [ngClass]="{'is-invalid': isInvalid}" [disabled]="isDisabled"
+      data-bs-auto-close="outside" [ngClass]="{'is-invalid': isInvalid, 'text-muted': !control?.value }" [disabled]="isDisabled"
       style="min-height:2.25rem;" [value]="control?.value">
-      {{ currentDisplay }}
+      {{ currentDisplay || placeholder }}
     </button>
 
     <!-- Calendar dropdowns -->
-    <span [hidden]="inline" class="dropdown-menu">
+    <span [hidden]="inline" class="dropdown-menu" #dropdownMenu>
       <ng-container *ngTemplateOutlet="calendarTemplate">
       </ng-container>
     </span>

--- a/projects/ngds-forms/src/lib/components/input-types/date-input/date-input.component.ts
+++ b/projects/ngds-forms/src/lib/components/input-types/date-input/date-input.component.ts
@@ -45,13 +45,18 @@ export class NgdsDateInput extends NgdsInput implements AfterViewInit {
   // Whether or not to allow range selections to include disabled dates. 
   @Input() allowDisabledInRange: boolean = false;
 
+  // Hide the datepicker once a date is picked
+  @Input() hideOnSelect: boolean = true;
+
   // A function that takes a DateTime as an argument and returns a boolean.
   // If the function returns true, the date associated with the supplied DateTime will be disabled.
   // If the function returns false, the date associated with the supplied DateTime will be available to select.
   @Input() customDisabledDatesCallback: (date: DateTime) => boolean;
 
-  // The dropdown that contains the datepicker/rangepicker calendar(s).
+  // The element that contains the dropdown trigger and the date selection calendars.
   @ViewChild('dropdown') dropdown: ElementRef;
+  // The template that contains the datepicker/rangepicker calendar(s).
+  @ViewChild('dropdownMenu') dropdownMenu: ElementRef;
 
   protected currentDisplay;
   protected selectedDate = new BehaviorSubject<any>(null);
@@ -107,10 +112,10 @@ export class NgdsDateInput extends NgdsInput implements AfterViewInit {
       return true;
     }
     if (this.minMode === 0) {
-      if (this.maxDate && date > this.maxDate) {
+      if (this.maxDate && date.day > this.maxDate.day) {
         return true;
       }
-      if (this.minDate && date < this.minDate) {
+      if (this.minDate && date.day < this.minDate.day) {
         return true;
       }
     }
@@ -159,6 +164,9 @@ export class NgdsDateInput extends NgdsInput implements AfterViewInit {
         } else {
           this.control.setValue([this.selectedDate.value, newDate]);
         }
+        if (this.hideOnSelect) {
+          this.hideCalendar();
+        }
       } else {
         // clear the dates and restart
         this.currentDisplay = `${this.convertDateTimeToFormat(e, this.dateDisplayFormat)} ${this.rangeSeparator} ...`;
@@ -170,6 +178,9 @@ export class NgdsDateInput extends NgdsInput implements AfterViewInit {
         this.control.setValue(this.convertDateTimeToFormat(e));
       } else {
         this.control.setValue(e);
+      }
+      if (this.hideOnSelect) {
+        this.hideCalendar();
       }
     }
   }
@@ -274,5 +285,13 @@ export class NgdsDateInput extends NgdsInput implements AfterViewInit {
    */
   onCalendarHide() {
     this.control.setValue(this.control?.value);
+  }
+
+  /**
+   * Manually hides the calendar.
+   */
+  hideCalendar() {
+    this.blur.emit();
+    this.dropdownMenu?.nativeElement?.classList?.remove('show');
   }
 };

--- a/src/app/forms/datepicker/datepickers/datepicker-snippets.ts
+++ b/src/app/forms/datepicker/datepickers/datepicker-snippets.ts
@@ -1,11 +1,12 @@
 export const snippets = {
   basicDatepicker: {
     html: `
-    <ngds-datepicker-input
+    <ngds-date-input
       [control]="form?.controls?.['basicDatepicker']"
       [label]="'My datepicker label'"
-      [subLabel]="'My datepicker sub-label'" [placeholder]="'My placeholder'">
-    </ngds-datepicker-input>`,
+      [subLabel]="'My datepicker sub-label'"
+      [placeholder]="'My placeholder'">
+    </ngds-date-input>`,
     ts: `
     import { Component, OnInit } from '@angular/core';
     import { UntypedFormControl, UntypedFormGroup} from '@angular/forms';
@@ -25,10 +26,10 @@ export const snippets = {
   },
   programmaticDatepicker: {
     html: `
-    <ngds-datepicker-input
+    <ngds-date-input
       [control]="form?.controls?.['programmaticDatePicker']"
       [resetButton]="true">
-    </ngds-datepicker-input>`,
+    </ngds-date-input>`,
     ts: `
     import { Component, OnInit } from '@angular/core';
     import { UntypedFormControl, UntypedFormGroup} from '@angular/forms';
@@ -48,12 +49,12 @@ export const snippets = {
   },
   inlineDatepicker: {
     html: `
-    <ngds-datepicker-input
+    <ngds-date-input
       [control]="form?.controls?.['inlineDatepicker']"
       [resetButton]="true"
       [inline]="true"
     >
-    </ngds-datepicker-input>`,
+    </ngds-date-input>`,
     ts: `
     import { Component, OnInit } from '@angular/core';
     import { UntypedFormControl, UntypedFormGroup} from '@angular/forms';
@@ -73,13 +74,13 @@ export const snippets = {
   },
   disabledLoadingDatepicker: {
     html: `
-    <ngds-datepicker-input
+    <ngds-date-input
        [control]="form?.controls?.['disabledDatepicker']"
        [resetButton]="true"
        [disabled]="isDisabled"
        [loadWhile]="isLoading"
        [inline]="true">
-    </ngds-datepicker-input>`,
+    </ngds-date-input>`,
     ts: `
     import { Component, OnInit } from '@angular/core';
     import { UntypedFormControl, UntypedFormGroup} from '@angular/forms';
@@ -116,12 +117,12 @@ export const snippets = {
   },
   minDatepicker: {
     html: `
-    <ngds-datepicker-input
+    <ngds-date-input
       [control]="form?.controls?.['minDatePicker']"
       [label]="'MinDate'" 
       [resetButton]="true"
       [minDate]="getToday()">
-    </ngds-datepicker-input>`,
+    </ngds-date-input>`,
     ts: `
     import { Component, OnInit } from '@angular/core';
     import { UntypedFormControl, UntypedFormGroup} from '@angular/forms';
@@ -146,12 +147,12 @@ export const snippets = {
   },
   maxDatepicker: {
     html: `
-    <ngds-datepicker-input
+    <ngds-date-input
       [control]="form?.controls?.['maxDatepicker']"
       [label]="'MaxDate'" 
       [resetButton]="true"
       [maxDate]="getToday()">
-    </ngds-datepicker-input>`,
+    </ngds-date-input>`,
     ts: `
     import { Component, OnInit } from '@angular/core';
     import { UntypedFormControl, UntypedFormGroup} from '@angular/forms';
@@ -176,11 +177,11 @@ export const snippets = {
   },
   customDisabledDatepicker: {
     html: `
-    <ngds-datepicker-input
+    <ngds-date-input
       [control]="form?.controls?.['customDisabledDatepicker']"
       [resetButton]="true"
       [customDisableDatesCallback]="customDisableDatesCallback">
-    </ngds-datepicker-input>`,
+    </ngds-date-input>`,
     ts: `
     import { Component, OnInit } from '@angular/core';
     import { UntypedFormControl, UntypedFormGroup} from '@angular/forms';
@@ -217,10 +218,10 @@ export const snippets = {
   },
   invalidDatepicker: {
     html: `
-    <ngds-datepicker-input
+    <ngds-date-input
       [control]="form?.controls?.['invalidDatepicker']"
       [resetButton]="true">
-    </ngds-datepicker-input>`,
+    </ngds-date-input>`,
     ts: `
     import { Component, OnInit } from '@angular/core';
     import { AbstractControl, UntypedFormControl, UntypedFormGroup, ValidationErrors, ValidatorFn } from '@angular/forms';
@@ -253,12 +254,12 @@ export const snippets = {
   },
   valueFormatDatepicker: {
     html: `
-    <ngds-datepicker-input
+    <ngds-date-input
       [control]="form?.controls?.['valueFormatDatepicker']"
       [label]="'Long Date Format'"
       [resetButton]="true"
       [dateFormat]="'ff'">
-    </ngds-datepicker-input>`,
+    </ngds-date-input>`,
     ts: `
     import { Component, OnInit } from '@angular/core';
     import { UntypedFormControl, UntypedFormGroup} from '@angular/forms';
@@ -278,12 +279,12 @@ export const snippets = {
   },
   rawDateTimeDatepicker: {
     html: `
-    <ngds-datepicker-input
+    <ngds-date-input
       [control]="form?.controls?.['rawDateTimeDatepicker']"
       [label]="'Return Raw DateTime'"
       [resetButton]="true"
       [dateFormat]="null">
-    </ngds-datepicker-input>`,
+    </ngds-date-input>`,
     ts: `
     import { Component, OnInit } from '@angular/core';
     import { UntypedFormControl, UntypedFormGroup} from '@angular/forms';
@@ -304,11 +305,11 @@ export const snippets = {
   },
   displayFormatDatepicker: {
     html: `
-    <ngds-datepicker-input
+    <ngds-date-input
       [control]="form?.controls?.['displayFormatDatepicker']"
       [resetButton]="true"
       [dateDisplayFormat]="customDisplayFormat">
-    </ngds-datepicker-input>`,
+    </ngds-date-input>`,
     ts: `
     import { Component, OnInit } from '@angular/core';
     import { UntypedFormControl, UntypedFormGroup} from '@angular/forms';
@@ -327,16 +328,40 @@ export const snippets = {
       }
     })`
   },
+  hideOnSelectDatepicker: {
+    html: `
+    <ngds-date-input
+      [control]="form?.controls?.['hideOnSelectDatepicker']"
+      [resetButton]="true"
+      [hideOnSelect]="false">
+    </ngds-date-input>`,
+    ts: `
+    import { Component, OnInit } from '@angular/core';
+    import { UntypedFormControl, UntypedFormGroup} from '@angular/forms';
+
+    @Component({
+      selector: 'hide-on-select-datepicker'
+      export class HideOnSelectDatepicker implements OnInit {
+        public form;
+
+        ngOnInit(): void {
+          this.form = new UntypedFormGroup({
+            hideOnSelectDatepicker: new UntypedFormControl(null),
+          })
+        }
+      }
+    })`
+  },
   timezoneUTC: {
     html: `
-    <ngds-datepicker-input
+    <ngds-date-input
       [control]="form?.controls?.['timezoneUTC']"
       [resetButton]="true"
       [timezone]="'UTC'"
       [dateDisplayFormat]="'X (z)'"
       [dateFormat]="'yyyy-LL-dd, hh:mm:ss'"
       [label]="'UTC'">
-    </ngds-datepicker-input>`,
+    </ngds-date-input>`,
     ts: `
     import { Component, OnInit } from '@angular/core';
     import { UntypedFormControl, UntypedFormGroup} from '@angular/forms';
@@ -356,14 +381,14 @@ export const snippets = {
   },
   timezoneKiritimati: {
     html: `
-    <ngds-datepicker-input
+    <ngds-date-input
       [control]="form?.controls?.['timezoneKiritimati']"
       [resetButton]="true"
       [timezone]="'Pacific/Kiritimati'"
       [dateDisplayFormat]="'X (z)'"
       [dateFormat]="'yyyy-LL-dd, hh:mm:ss'"
       [label]="'Pacific/Kiritimati (UTC+14)'">
-    </ngds-datepicker-input>`,
+    </ngds-date-input>`,
     ts: `
     import { Component, OnInit } from '@angular/core';
     import { UntypedFormControl, UntypedFormGroup} from '@angular/forms';
@@ -383,14 +408,14 @@ export const snippets = {
   },
   timezoneNiue: {
     html: `
-    <ngds-datepicker-input
+    <ngds-date-input
       [control]="form?.controls?.['timezoneNiue']"
       [resetButton]="true"
       [timezone]="'Pacific/Niue'"
       [dateDisplayFormat]="'X (z)'"
       [dateFormat]="'yyyy-LL-dd, hh:mm:ss'"
       [label]="'Pacific/Niue (UTC-11)'">
-    </ngds-datepicker-input>`,
+    </ngds-date-input>`,
     ts: `
     import { Component, OnInit } from '@angular/core';
     import { UntypedFormControl, UntypedFormGroup} from '@angular/forms';
@@ -410,13 +435,13 @@ export const snippets = {
   },
   minModeMonth: {
     html: `
-    <ngds-datepicker-input
+    <ngds-date-input
       [control]="form?.controls?.['minModeMonth']"
       [resetButton]="true"
       [minMode]="1"
       [dateDisplayFormat]="'LLLL, yyyy'"
       [label]="'Month (minMode 1)'">
-    </ngds-datepicker-input>`,
+    </ngds-date-input>`,
     ts: `
     import { Component, OnInit } from '@angular/core';
     import { UntypedFormControl, UntypedFormGroup} from '@angular/forms';
@@ -436,13 +461,13 @@ export const snippets = {
   },
   minModeYear: {
     html: `
-    <ngds-datepicker-input
+    <ngds-date-input
       [control]="form?.controls?.['minModeYear']"
       [resetButton]="true"
       [minMode]="2"
       [dateDisplayFormat]="'yyyy'"
       [label]="'Year (minMode 2)'">
-    </ngds-datepicker-input>`,
+    </ngds-date-input>`,
     ts: `
     import { Component, OnInit } from '@angular/core';
     import { UntypedFormControl, UntypedFormGroup} from '@angular/forms';

--- a/src/app/forms/datepicker/datepickers/datepickers.component.html
+++ b/src/app/forms/datepicker/datepickers/datepickers.component.html
@@ -1,10 +1,18 @@
 <h2>Datepickers</h2>
 <section>
   <p>
-    NGDS Forms Datepicker leverages <a href="https://moment.github.io/luxon/#/">luxon</a>.
+    NGDS Forms Datepicker leverages <a href="https://moment.github.io/luxon/#/">luxon</a> and <a
+      href="https://popper.js.org/">popper.js</a>.
   </p>
   <pre class="border rounded px-3 py-1"><code class="p-0" [highlight]="luxonCode"></code></pre>
 </section>
+
+<h4>Browser time</h4>
+
+<pre class="border rounded px-3 py-1">
+  <code class="p-0">Current browser time: {{ now?.value?.toFormat('DDDD TT (z)') }}</code>
+  <code class="p-0">Current UTC time: {{ now?.value?.setZone('UTC').toFormat('DDDD TT (z)') }}</code>
+</pre>
 
 <section #section id="basicDatepicker" class="mb-5 mt-3">
   <h3>Basic Datepicker</h3>
@@ -51,9 +59,10 @@
     Disabled and loading state can be controlled with <code>[disabled]</code> and <code>[loadWhile]</code> attributes,
     respectively. You can also disable the control programmatically by calling <code>control.disable()</code>.
   </p>
-  <demonstrator [htmlFile]="snippets?.disabledLoadingDatepicker?.html" [tsFile]="snippets?.disabledLoadingDatepicker?.ts"
-    [control]="form?.controls?.['disabledLoadingDatepicker']">
-    <ngds-date-input [control]="form?.controls?.['disabledLoadingDatepicker']" [resetButton]="true" [disabled]="isDisabled" [loadWhile]="isLoading" [inline]="true">
+  <demonstrator [htmlFile]="snippets?.disabledLoadingDatepicker?.html"
+    [tsFile]="snippets?.disabledLoadingDatepicker?.ts" [control]="form?.controls?.['disabledLoadingDatepicker']">
+    <ngds-date-input [control]="form?.controls?.['disabledLoadingDatepicker']" [resetButton]="true"
+      [disabled]="isDisabled" [loadWhile]="isLoading" [inline]="true">
     </ngds-date-input>
     <div class="form-check form-switch mt-2">
       <input class="form-check-input" type="checkbox" id="flexSwitchDisabled" (click)="disabledSwitch()">
@@ -80,7 +89,8 @@
   </p>
   <p>
     You must pass in a <code>luxon</code> DateTime object as the argument for <code>minDate</code> and
-    <code>maxDate</code>.
+    <code>maxDate</code>. Keep in mind that the default NGDS Datepicker timezone is <code>UTC</code>. Ensure the
+    DateTime you pass in contains the appropriate timezone.
   </p>
   <p>In the examples below, <code>minDate</code> and <code>maxDate</code> are both set to <code>today</code>.</p>
   <demonstrator [htmlFile]="snippets?.minDatepicker.html" [tsFile]="snippets?.minDatepicker.ts"
@@ -92,7 +102,7 @@
   <div class="mt-2"></div>
   <demonstrator [htmlFile]="snippets?.maxDatepicker.html" [tsFile]="snippets?.maxDatepicker.ts"
     [control]="form?.controls?.['maxDatepicker']">
-    <ngds-date-input [maxDate]="getToday()" [label]="'MaxDate'" [control]="form?.controls?.['maxDatepicker']" 
+    <ngds-date-input [maxDate]="getToday()" [label]="'MaxDate'" [control]="form?.controls?.['maxDatepicker']"
       [resetButton]="true">
     </ngds-date-input>
   </demonstrator>
@@ -244,6 +254,19 @@
     [control]="form?.controls?.['displayFormatDatepicker']">
     <ngds-date-input [control]="form?.controls?.['displayFormatDatepicker']" [resetButton]="true"
       [dateDisplayFormat]="customDisplayFormat">
+    </ngds-date-input>
+  </demonstrator>
+</section>
+
+<section #section id="hideOnClickDatepicker" class="mb-5 mt-3">
+  <h3>Persist datepicker on click</h3>
+  <p>
+    By default, the calendar will hide itself when a date is selected. To keep the calendar open after a date is
+    selected, set <code>[hideOnSelect]="false"</code>. This does not apply to inline datepickers.
+  </p>
+  <demonstrator [htmlFile]="snippets?.hideOnSelectDatepicker.html" [tsFile]="snippets?.hideOnSelectDatepicker.ts"
+    [control]="form?.controls?.['hideOnSelectDatepicker']">
+    <ngds-date-input [control]="form?.controls?.['hideOnSelectDatepicker']" [resetButton]="true" [hideOnSelect]="false">
     </ngds-date-input>
   </demonstrator>
 </section>

--- a/src/app/forms/datepicker/datepickers/datepickers.component.ts
+++ b/src/app/forms/datepicker/datepickers/datepickers.component.ts
@@ -15,7 +15,7 @@ export class DatepickersComponent implements OnInit, AfterViewInit {
   public fields: any = {};
   public now = new BehaviorSubject(null);
   public snippets = snippets;
-  public luxonCode = `yarn add luxon`;
+  public luxonCode = `yarn add luxon \nyarn add @popperjs/core`;
   public isDisabled = false;
   public isLoading = false;
   public customDisplayFormat = "DDDD"
@@ -52,6 +52,7 @@ export class DatepickersComponent implements OnInit, AfterViewInit {
       valueFormatDatepicker: new UntypedFormControl(null),
       rawDateTimeDatepicker: new UntypedFormControl(DateTime.now(), { nonNullable: true }),
       displayFormatDatepicker: new UntypedFormControl(null),
+      hideOnSelectDatepicker: new UntypedFormControl(null),
       timezoneUTC: new UntypedFormControl(null),
       timezoneNiue: new UntypedFormControl(null),
       timezoneKiritimati: new UntypedFormControl(null),
@@ -64,7 +65,7 @@ export class DatepickersComponent implements OnInit, AfterViewInit {
     }
 
     setInterval(()=>{
-      this.now.next(this.getToday());
+      this.now.next(DateTime.now());
     },1000);
   }
 
@@ -86,7 +87,7 @@ export class DatepickersComponent implements OnInit, AfterViewInit {
 
   getParsedNow(){
     const formatted = this.getFormattedNow();
-    return DateTime.fromFormat(formatted, this.form.controls['reversableChecker'].value)
+    return DateTime.fromFormat(formatted, this.form.controls['reversableChecker'].value, {zone: 'UTC'});
   }
 
   checkTokenString(){
@@ -129,6 +130,10 @@ export class DatepickersComponent implements OnInit, AfterViewInit {
   }
 
   getToday() {
+    return DateTime.now().setZone('UTC');
+  }
+
+  getBrowserTime() {
     return DateTime.now();
   }
 

--- a/src/app/forms/datepicker/rangepickers/rangepicker-snippets.ts
+++ b/src/app/forms/datepicker/rangepickers/rangepicker-snippets.ts
@@ -1,12 +1,13 @@
 export const snippets = {
   basicRangepicker: {
     html: `
-    <ngds-datepicker-input
+    <ngds-date-input
       [control]="form?.controls?.['basicRangepicker']"
       [dateRange]="true"
       [label]="'My rangepicker label'"
-      [subLabel]="'My rangepicker sub-label'" [placeholder]="'My placeholder'">
-    </ngds-datepicker-input>`,
+      [subLabel]="'My rangepicker sub-label'"
+      [placeholder]="'My placeholder'">
+    </ngds-date-input>`,
     ts: `
     import { Component, OnInit } from '@angular/core';
     import { UntypedFormControl, UntypedFormGroup} from '@angular/forms';

--- a/src/app/forms/datepicker/rangepickers/rangepickers.component.html
+++ b/src/app/forms/datepicker/rangepickers/rangepickers.component.html
@@ -2,13 +2,20 @@
 </h2>
 <section>
   <p>
-    NGDS Forms Rangepicker leverages <a href="https://moment.github.io/luxon/#/">luxon</a>.
+    NGDS Forms Rangepicker leverages <a href="https://moment.github.io/luxon/#/">luxon</a> and <a href="https://popper.js.org/">popper.js</a>.
   </p>
   <pre class="border rounded px-3 py-1"><code class="p-0" [highlight]="luxonCode"></code></pre>
   <p>
     Rangepicker functionality is currently in beta.
   </p>
 </section>
+
+<h4>Browser time</h4>
+<pre class="border rounded px-3 py-1">
+  <code class="p-0">Current browser time: {{ now?.value?.toFormat('DDDD TT (z)') }}</code>
+  <code class="p-0">Current UTC time: {{ now?.value?.setZone('UTC').toFormat('DDDD TT (z)') }}</code>
+</pre>
+
 
 <section #section id="basicRangepicker" class="mb-5 mt-3">
   <h3>Basic Rangepicker</h3>

--- a/src/app/forms/datepicker/rangepickers/rangepickers.component.ts
+++ b/src/app/forms/datepicker/rangepickers/rangepickers.component.ts
@@ -14,7 +14,7 @@ export class RangepickersComponent {
   public form;
   public fields;
   public snippets = snippets
-  public luxonCode = `yarn add luxon`;
+  public luxonCode = `yarn add luxon \nyarn add @popperjs/core`;
   public isDisabled = false;
   public isLoading = false;
   public now = new BehaviorSubject(null);


### PR DESCRIPTION
## Whats New:

- Fixed a bug where the placeholder was not showing for datepicker and rangepicker elements
- Sublabel font size is smaller
- Fixed a typo where the showcase app showed `<ngds-datepicker-input>` as the datepicker element tag. Fixed to read `<ngds-date-input>`.
- Fixed a bug where the showcase app was using browser time for min/max dates in the datepicker. While the datepicker was functioning correctly, it gave the impression that it was not setting min/max dates correctly as the internal forms timezone was UTC. Fixed so that the showcase app sends UTC dates for min/max limits
- New functionality: by default, the datepicker dropdown now closes when a new date is selected. The datepicker can be persisted on click by setting `[hideOnSelect]="false"`.