### PR TITLE
Updating dirty touched logic

### DIFF
--- a/projects/ngds-forms/src/lib/components/input-types/date-input/date-input.component.ts
+++ b/projects/ngds-forms/src/lib/components/input-types/date-input/date-input.component.ts
@@ -245,13 +245,21 @@ export class NgdsDateInput extends NgdsInput implements AfterViewInit {
           this.selectedDate.next(e[0]);
           this.selectedEndDate.next(e[1]);
         }
+        this.control.markAsDirty();
+        this.control.updateValueAndValidity();
       }
     } else {
       // expect string
-      if (this.dateFormat && e) {
-        this.selectedDate.next(DateTime.fromFormat(e, this.dateFormat, { zone: this.timezone }));
+      if (e) {
+        if (this.dateFormat) {
+          this.selectedDate.next(DateTime.fromFormat(e, this.dateFormat, { zone: this.timezone }));
+        } else {
+          this.selectedDate.next(e);
+        }
+        this.control.markAsDirty();
+        this.control.updateValueAndValidity();
       } else {
-        this.selectedDate.next(e || null);
+        this.selectedDate.next(null);
       }
     }
   }
@@ -294,6 +302,7 @@ export class NgdsDateInput extends NgdsInput implements AfterViewInit {
    * We can trigger this reset by just setting the control value to itself. 
    */
   onCalendarHide() {
+    this.control.markAsTouched();
     this.control.setValue(this.control?.value);
   }
 

--- a/projects/ngds-forms/src/lib/components/input-types/ngds-input.component.ts
+++ b/projects/ngds-forms/src/lib/components/input-types/ngds-input.component.ts
@@ -165,11 +165,9 @@ export class NgdsInput implements OnInit, OnDestroy {
       if (this.emitValueChangeWhenNull) {
         // Emit status change only if the value isn't null or undefined
         this.valueChange.emit(res);
-        this.control.markAsDirty();
       } else {
         if (res !== null && res !== undefined) {
           this.valueChange.emit(res);
-          this.control.markAsDirty();
         }
       }
     }));
@@ -245,8 +243,10 @@ export class NgdsInput implements OnInit, OnDestroy {
       }
     }
     if (this.isInvalid) {
+      if (type === 'toggle') {
+        classes["was-validated"] = true;
+      }
       classes["is-invalid"] = true;
-      classes["was-validated"] = true;
       classes["border-danger"] = true;
     } else {
     }
@@ -291,7 +291,7 @@ export class NgdsInput implements OnInit, OnDestroy {
     } else {
       this.control.setValue(value);
     }
-    this.control.markAsDirty();
+    this.control.updateValueAndValidity();
   }
 
   multiselectAll() {

--- a/projects/ngds-forms/src/lib/components/input-types/picklist-input/picklist-input.component.html
+++ b/projects/ngds-forms/src/lib/components/input-types/picklist-input/picklist-input.component.html
@@ -28,7 +28,7 @@
       </div>
       <!-- Dropdown menu -->
       <ul *dropdownMenu class="dropdown-menu" role="menu">
-        <li *ngFor="let option of selectionListItems" (click)="updateValue(option?.value || option)" role="menuitem" class="option-item">
+        <li *ngFor="let option of selectionListItems" (click)="onValueChange(option?.value || option)" role="menuitem" class="option-item">
           <!-- Display current menu item as template -->
           <ng-container *ngIf="showTemplate()" [ngTemplateOutlet]="selectionListTemplate"
             [ngTemplateOutletContext]="{data: option}"></ng-container>

--- a/projects/ngds-forms/src/lib/components/input-types/picklist-input/picklist-input.component.ts
+++ b/projects/ngds-forms/src/lib/components/input-types/picklist-input/picklist-input.component.ts
@@ -26,6 +26,12 @@ export class NgdsPicklistInput extends NgdsInput {
     return false;
   }
 
+  onValueChange(value) {
+    this.updateValue(value);
+    this.control.markAsDirty();
+    this.control.updateValueAndValidity();
+  }
+
   onOpenChange(e) {
     if (e) {
       this.onFocus();

--- a/projects/ngds-forms/src/lib/components/input-types/typeahead-input/typeahead-input.component.ts
+++ b/projects/ngds-forms/src/lib/components/input-types/typeahead-input/typeahead-input.component.ts
@@ -101,6 +101,8 @@ export class NgdsTypeaheadInput extends NgdsInput implements AfterViewInit {
     });
     if (match) {
       this.updateValue(match.value);
+      this.control.markAsDirty();
+      this.control.updateValueAndValidity();
     } else {
       this.updateValue(null);
     }


### PR DESCRIPTION
Before, `dirty` status was triggered every time the form value changes. It has now been adjusted to more accurately follow the ruleset for a conventional `dirty` and `touched` fields:

- All controls are initialized as `untouched` and `pristine`.
- A control becomes `touched` when the `(blur)` event fires (ie the field loses focus after being focused).
- A field becomes `dirty` if the UI is used to change the form value.