### PR TITLE
Adding console error when no control added to form

### DIFF
--- a/projects/ngds-forms/src/lib/components/input-addons/multiselect-item/multiselect-item.component.html
+++ b/projects/ngds-forms/src/lib/components/input-addons/multiselect-item/multiselect-item.component.html
@@ -1,4 +1,4 @@
-<div class="border bg-light d-flex rounded-pill" [ngClass]="{'text-muted': disabled}">
+<div class="border bg-light d-flex rounded-pill text-truncate" [ngClass]="{'text-muted': disabled}">
   <!-- Show correct option display value -->
   <div class="col-auto mx-2">{{option?.display || option?.value || option}}</div>
   <!-- Remove option button -->

--- a/projects/ngds-forms/src/lib/components/input-types/date-input/date-input.component.html
+++ b/projects/ngds-forms/src/lib/components/input-types/date-input/date-input.component.html
@@ -10,7 +10,7 @@
 <div class="d-flex position-relative">
   <!-- Input wrapper -->
   <div
-    class="input-group border rounded-3 d-flex align-items-center dropdown"
+    class="input-group border rounded-3 d-flex align-items-center dropdown overflow-hidden"
     [ngClass]="getWrapperClasses()"
     #dropdownElement
   >

--- a/projects/ngds-forms/src/lib/components/input-types/ngds-input.component.ts
+++ b/projects/ngds-forms/src/lib/components/input-types/ngds-input.component.ts
@@ -181,6 +181,15 @@ export class NgdsInput implements OnInit, OnDestroy {
   }
 
   ngOnInit(): void {
+    // If no control is provided, throw an error.
+    if (!this.control) {
+      let errorMessage = 'An NGDS-Form element is missing a defined form control. Please provide a control to bind to [control].';
+      if (this.label) {
+        errorMessage += ` Control label: '${this.label}'`;
+      }
+      throw new Error(errorMessage);
+    };
+
     // attach unique control id
     this.control['id'] = this.controlId;
 

--- a/projects/ngds-forms/src/lib/components/input-types/number-input/number-input.component.html
+++ b/projects/ngds-forms/src/lib/components/input-types/number-input/number-input.component.html
@@ -5,7 +5,7 @@
 <div class="d-flex position-relative">
 
   <!-- Input wrapper -->
-  <div class="input-group border rounded-3 d-flex align-items-center" [ngClass]="getWrapperClasses()">
+  <div class="input-group border rounded-3 d-flex align-items-center overflow-hidden" [ngClass]="getWrapperClasses()">
 
     <!-- Prepended content -->
     <ng-content #inputPrepend select="[ngdsInputPrepend]"></ng-content>

--- a/projects/ngds-forms/src/lib/components/input-types/picklist-input/picklist-input.component.html
+++ b/projects/ngds-forms/src/lib/components/input-types/picklist-input/picklist-input.component.html
@@ -11,7 +11,7 @@
   <!-- Input wrapper -->
   <div
     #dropdownElement
-    class="input-group border rounded-3 position-relative"
+    class="input-group border rounded-3 position-relative overflow-hidden"
     [ngClass]="getWrapperClasses()"
   >
 
@@ -27,7 +27,7 @@
       type="button"
       role="select"
       style="min-height: 2.25rem; margin-left: 1px;"
-      class="form-select border-0 text-start rounded-3"
+      class="form-select border-0 text-start rounded-3 oveflow-hidden"
       [ngClass]="getInputClasses()"
       [disabled]="isDisabled"
       [value]="control?.value"
@@ -37,10 +37,10 @@
       <!-- Multiselect display items -->
       <div
         *ngIf="multiselect && control?.value?.length"
-        class="m-0 d-flex justify-content-left row"
+        class="m-0 d-flex justify-content-left row oveflow-hidden"
       >
         <ngds-multiselect-item
-          class="col-auto p-0 my-0 me-1"
+          class="col-auto p-0 my-0 me-1 oveflow-hidden"
           *ngFor="let item of control?.value"
           [option]="getOptionByValue(item)"
           (remove)="removeValue($event)"

--- a/projects/ngds-forms/src/lib/components/input-types/text-input/text-input.component.html
+++ b/projects/ngds-forms/src/lib/components/input-types/text-input/text-input.component.html
@@ -4,7 +4,7 @@
 <!-- Text input -->
 <div class="d-flex position-relative">
   <!-- Input wrapper -->
-  <div class="input-group border rounded-3 d-flex align-items-center" [ngClass]="getWrapperClasses()">
+  <div class="input-group border rounded-3 d-flex align-items-center overflow-hidden" [ngClass]="getWrapperClasses()">
 
     <!-- Prepended content -->
     <ng-content #inputPrepend select="[ngdsInputPrepend]"></ng-content>

--- a/projects/ngds-forms/src/lib/components/input-types/typeahead-input/typeahead-input.component.html
+++ b/projects/ngds-forms/src/lib/components/input-types/typeahead-input/typeahead-input.component.html
@@ -9,7 +9,7 @@
 <!-- Input wrapper -->
 <div
   #dropdownElement
-  class="input-group border rounded-3 position-relative"
+  class="input-group border rounded-3 position-relative overflow-hidden"
   [ngClass]="getWrapperClasses()"
 >
 

--- a/src/app/forms/datepicker/datepickers/datepickers.component.html
+++ b/src/app/forms/datepicker/datepickers/datepickers.component.html
@@ -281,7 +281,7 @@
   </p>
   <p>
     In the examples below, the display of each control is the Unix timestamp associated with the date picked, however
-    the values should be the same for each zone.
+    the actual values should be the same for each zone as they are referring to the calendar date only (each value should be the date selected at 00:00:00).
   </p>
   <p>
     Change your browser's timezone to see how NGDS Datepickers are affected by timezones. There should be no difference

--- a/src/app/forms/picklists/picklists.component.ts
+++ b/src/app/forms/picklists/picklists.component.ts
@@ -1,5 +1,5 @@
 import { AfterViewInit, Component, OnInit, TemplateRef, ViewChild, ViewChildren } from '@angular/core';
-import { AbstractControl, UntypedFormControl, UntypedFormGroup, ValidationErrors, ValidatorFn } from '@angular/forms';
+import { AbstractControl, UntypedFormControl, UntypedFormGroup, ValidationErrors, ValidatorFn, Validators } from '@angular/forms';
 import { Subscription } from 'rxjs';
 
 import { snippets } from './picklist-snippets';
@@ -57,7 +57,7 @@ export class PicklistsComponent implements OnInit, AfterViewInit {
         displayPicklist: new UntypedFormControl(null),
         customPicklist: new UntypedFormControl(null),
         disabledPicklist: new UntypedFormControl(null),
-        invalidPicklist: new UntypedFormControl(null, [this.customValidator()]),
+        invalidPicklist: new UntypedFormControl(null, [Validators.required, this.customValidator()]),
         inlinePicklist: new UntypedFormControl(null),
         changeSelectList: new UntypedFormControl(null),
         autoCloseBehaviour: new UntypedFormControl(null),


### PR DESCRIPTION
Console warning occurs when the control directive fails to bind an Angular FormControl to an `ngds-input`. If a label is provided to the form, the warning includes the label to help with troubleshooting.

Also improved field truncation when using very small screens.