### PR TITLE
adding displaySelectionItems options

### DIFF
--- a/projects/ngds-forms/src/lib/components/input-types/ngds-dropdown.component.ts
+++ b/projects/ngds-forms/src/lib/components/input-types/ngds-dropdown.component.ts
@@ -12,6 +12,9 @@ export class NgdsDropdown extends NgdsInput implements AfterViewInit {
 
   @Input() autoCloseBehaviour: String | 'inside' | 'outside' | 'true' | 'false' = 'inside';
 
+  // The no results text to display when there are no matches.
+  @Input() noResultsText: string = 'No matching results';
+
   @Output() onDropdownHide = new EventEmitter<void>();
   @Output() onDropdownShow = new EventEmitter<void>();
 
@@ -28,6 +31,7 @@ export class NgdsDropdown extends NgdsInput implements AfterViewInit {
   protected dropdownInputType;
 
   protected bsDropdown: any = null;
+
 
   // The status of the dropdown. If true, the dropdown is open. If false, the dropdown is closed.
   protected _isOpen = new BehaviorSubject<boolean>(false);
@@ -287,6 +291,13 @@ export class NgdsDropdown extends NgdsInput implements AfterViewInit {
 
   isClickInsideMenu(event) {
     return this.dropdownMenu.nativeElement.contains(event.target);
+  }
+
+  getTemplate() {
+    if (this.selectionListTemplate) {
+      return this.selectionListTemplate;
+    }
+    return this.defaultListTemplate;
   }
 
 

--- a/projects/ngds-forms/src/lib/components/input-types/picklist-input/picklist-input.component.html
+++ b/projects/ngds-forms/src/lib/components/input-types/picklist-input/picklist-input.component.html
@@ -11,7 +11,7 @@
   <!-- Input wrapper -->
   <div
     #dropdownElement
-    class="input-group border rounded-3 position-relative"
+    class="input-group border rounded-3 d-flex align-items-center position-relative"
     [ngClass]="getWrapperClasses()"
   >
 
@@ -27,7 +27,7 @@
       type="button"
       role="select"
       style="min-height: 2.25rem; margin-left: 1px;"
-      class="form-select border-0 text-start rounded-3 overflow-hidden"
+      class="form-select px-2 py-0 border-0 text-start rounded-3 overflow-hidden"
       [ngClass]="getInputClasses()"
       [disabled]="isDisabled"
       [value]="control?.value"
@@ -37,10 +37,10 @@
       <!-- Multiselect display items -->
       <div
         *ngIf="multiselect && control?.value?.length"
-        class="m-0 d-flex justify-content-left row"
+        class="m-0 p-0 d-flex justify-content-left row"
       >
         <ngds-multiselect-item
-          class="col-auto p-0 my-0 me-1"
+          class="col-auto p-0 m-1"
           *ngFor="let item of control?.value"
           [option]="getOptionByValue(item)"
           (remove)="removeValue($event)"
@@ -110,8 +110,13 @@
     role="menu"
   >
     <li
-      *ngFor="let option of selectionListItems"
-      (click)="onValueChange(option?.value || option, true)"
+      *ngIf="displayedSelectionListItems?.length === 0"
+      class="dropdown-item text-muted"
+    >
+      {{ noResultsText }}
+    </li>
+    <li
+      *ngFor="let option of displayedSelectionListItems;"
       role="menuitem"
       class="option-item"
       href="#"
@@ -130,10 +135,12 @@
       <button
         *ngIf="!showTemplate()"
         class="dropdown-item"
-        (click)="onValueChange(option?.value || option, true)"
+        (click)="onValueChange(option, true)"
         value="{{ option?.value || option }}"
+        [disabled]="option?.disabled || false"
       >
         {{ getDisplayByValue( option?.value || option) }}
       </button>
+    </li>
   </ul>
 </ng-template>

--- a/projects/ngds-forms/src/lib/components/input-types/picklist-input/picklist-input.component.ts
+++ b/projects/ngds-forms/src/lib/components/input-types/picklist-input/picklist-input.component.ts
@@ -8,8 +8,6 @@ import { NgdsDropdown } from '../ngds-dropdown.component';
 })
 export class NgdsPicklistInput extends NgdsDropdown {
 
-  @ViewChild('defaultTemplate') defaultTemplate: TemplateRef<any>;
-
   constructor(
     private picklistCd: ChangeDetectorRef,
     private picklistRenderer: Renderer2,
@@ -39,11 +37,14 @@ export class NgdsPicklistInput extends NgdsDropdown {
     return false;
   }
 
-  onValueChange(value, byClick = false) {
+  onValueChange(option, byClick = false) {
+    if (option?.disabled) {
+      return;
+    }
     if (byClick) {
       this.lastChangedBySelect = true;
     }
-    this.updateValue(value);
+    this.updateValue(option?.value || option);
     this.control.markAsDirty();
     this.control.markAsTouched();
     this.control.updateValueAndValidity();

--- a/projects/ngds-forms/src/lib/components/input-types/typeahead-input/typeahead-input.component.html
+++ b/projects/ngds-forms/src/lib/components/input-types/typeahead-input/typeahead-input.component.html
@@ -21,7 +21,7 @@
 
   <!-- Input -->
   <div
-    class="form-input border-0 rounded-5 d-flex w-100 overflow-hidden"
+    class="form-input border-0 d-flex w-100 overflow-hidden"
     style="min-height: 2.25rem"
     [ngClass]="getInputClasses()"
   >
@@ -69,7 +69,7 @@
         style="max-height: 250px; overflow-y: auto; min-width: 400px"
       >
         <ng-content
-          *ngTemplateOutlet="getTemplate(); context: {matches: refinedListItems, items: selectionListItems, query: currentDisplay }"
+          *ngTemplateOutlet="getTemplate(); context: {matches: refinedListItems, items: displayedSelectionListItems, query: currentDisplay }"
         ></ng-content>
       </ul>
     </div>
@@ -139,6 +139,7 @@
     [ngClass]="{'active': match.value === control?.value}"
     type="menuitem"
     value="{{ match?.value || match}}"
+    [disabled]="match?.disabled"
   >
     <div [innerHtml]="match?.innerHtml"></div>
   </button>

--- a/projects/ngds-forms/src/lib/components/input-types/typeahead-input/typeahead-input.component.ts
+++ b/projects/ngds-forms/src/lib/components/input-types/typeahead-input/typeahead-input.component.ts
@@ -16,8 +16,6 @@ export class NgdsTypeaheadInput extends NgdsDropdown implements AfterViewInit {
   @Input() optionsLimit: number = -1;
   // Controls whether or not to use case sensitive matching in the dropdown.
   @Input() caseSensitiveMatching: boolean = false;
-  // The no results text to display when there are no matches.
-  @Input() noResultsText: string = 'No matching results';
 
   // protected bsUtils = new bootstrap;
 
@@ -55,7 +53,7 @@ export class NgdsTypeaheadInput extends NgdsDropdown implements AfterViewInit {
       }
     }));
     // // watch selectionlistitems for changes
-    this.subscriptions.add(this._selectionListItems.subscribe(() => {
+    this.subscriptions.add(this._displayedSelectionListItems.subscribe(() => {
       this.onSelectionListItemsChange();
     }));
     // Watch for changes to focus/blur
@@ -74,10 +72,11 @@ export class NgdsTypeaheadInput extends NgdsDropdown implements AfterViewInit {
 
   onSelectionListItemsChange() {
     // update matchlist
-    this.matchList = this.selectionListItems.map((item) => {
+    this.matchList = this.displayedSelectionListItems.map((item) => {
       const matchItem = {
         value: item?.value || item,
         display: item?.display || item?.value || item,
+        disabled: item?.disabled || false,
       };
       let matcher = item?.display || item?.value || item;
       if (!this.caseSensitiveMatching) {
@@ -107,6 +106,9 @@ export class NgdsTypeaheadInput extends NgdsDropdown implements AfterViewInit {
 
   // Fires when item is clicked in the dropdown
   selected(item) {
+    if (item?.disabled) {
+      return;
+    }
     this.lastChangedBySelect = true;
     if (this.multiselect) {
       this.typeaheadChange(null, false);
@@ -170,7 +172,8 @@ export class NgdsTypeaheadInput extends NgdsDropdown implements AfterViewInit {
         return {
           value: item.value,
           innerHtml: this.getHighlightedMatch(item, value),
-          display: item.display
+          display: item.display,
+          disabled: item.disabled || false,
         };
       });
       // focus the first item in the list
@@ -226,14 +229,6 @@ export class NgdsTypeaheadInput extends NgdsDropdown implements AfterViewInit {
       return this.placeholder;
     }
     return '';
-  }
-
-  // Get the dropdown list template
-  getTemplate() {
-    if (this.selectionListTemplate) {
-      return this.selectionListTemplate;
-    }
-    return this.defaultListTemplate;
   }
 
   // Highlight the portion of the option that has been typed in

--- a/projects/ngds-forms/src/lib/form-models.ts
+++ b/projects/ngds-forms/src/lib/form-models.ts
@@ -1,4 +1,5 @@
 export interface SelectionItemSchema {
   readonly value?: any,
   display?: any,
+  disabled?: boolean,
 }

--- a/src/app/forms/multiselects/multiselect-snippets.ts
+++ b/src/app/forms/multiselects/multiselect-snippets.ts
@@ -163,6 +163,89 @@ export const snippets = {
       }
     })`
   },
+  displayOptionsPicklistMulti: {
+    html: `
+    <ngds-picklist-input
+      [control]="form?.controls?.['displayOptionsPicklistMulti']"
+      [selectionListItems]="displayProvinceList"
+      [displaySelectionItems]="disabled"
+      [multiselect]="true"
+      [resetButton]="true"
+      [selectAllButton]="true"
+      [placeholder]="'Select multiple'">
+    </ngds-picklist-input>`,
+    ts: `
+    import { Component, OnInit } from '@angular/core';
+    import { UntypedFormControl, UntypedFormGroup} from '@angular/forms';
+
+    @Component({
+      selector: 'display-options-picklist-multiselect'
+      export class DisplayOptionsPicklistMulti implements OnInit {
+        public form;
+
+        displayProvinceList = [
+          {
+            value: '0001',
+            display: 'British Columbia'
+          },
+          {
+            value: '0002',
+            display: 'Alberta'
+          },
+          {
+            value: '0003',
+            display: 'Saskatchewan'
+          },
+          {
+            value: '0004',
+            display: 'Manitoba'
+          },
+          {
+            value: '0005',
+            display: 'Ontario'
+          },
+          {
+            value: '0006',
+            display: 'Quebec'
+          },
+          {
+            value: '0007',
+            display: 'Nova Scotia'
+          },
+          {
+            value: '0008',
+            display: 'Newfoundland and Labrador'
+          },
+          {
+            value: '0009',
+            display: 'New Brunswick'
+          },
+          {
+            value: '0010',
+            display: 'Prince Edward Island'
+          },
+          {
+            value: '0011',
+            display: 'Yukon'
+          },
+          {
+            value: '0012',
+            display: 'Northwest Territories'
+          },
+          {
+            value: '0013',
+            display: 'Nunavut'
+          },
+        ]
+
+        ngOnInit(): void {
+          this.form = new UntypedFormGroup({
+            displayOptionsPicklistMulti: new UntypedFormControl([]), // best to make your default an empty array for multiselects
+          })
+        }
+      }
+    })`
+  },
     basicTypeaheadMulti: {
     html: `
     <ngds-picklist-input
@@ -240,6 +323,89 @@ export const snippets = {
         ngOnInit(): void {
           this.form = new UntypedFormGroup({
             basicTypeaheadMulti: new UntypedFormControl([]), // best to make your default an empty array for multiselects
+          })
+        }
+      }
+    })`
+  },
+  displayOptionsTypeaheadMulti: {
+    html: `
+    <ngds-typeahead-input
+      [control]="form?.controls?.['displayOptionsTypeaheadMulti']"
+      [selectionListItems]="displayProvinceList"
+      [displaySelectionItems]="'disabled'"
+      [multiselect]="true"
+      [resetButton]="true"
+      [selectAllButton]="true"
+      [placeholder]="'Select multiple'">
+    </ngds-typeahead-input>`,
+    ts: `
+    import { Component, OnInit } from '@angular/core';
+    import { UntypedFormControl, UntypedFormGroup} from '@angular/forms';
+
+    @Component({
+      selector: 'display-options-typeahead-multiselect'
+      export class DisplayOptionsTypeaheadMultiselect implements OnInit {
+        public form;
+
+        displayProvinceList = [
+          {
+            value: '0001',
+            display: 'British Columbia'
+          },
+          {
+            value: '0002',
+            display: 'Alberta'
+          },
+          {
+            value: '0003',
+            display: 'Saskatchewan'
+          },
+          {
+            value: '0004',
+            display: 'Manitoba'
+          },
+          {
+            value: '0005',
+            display: 'Ontario'
+          },
+          {
+            value: '0006',
+            display: 'Quebec'
+          },
+          {
+            value: '0007',
+            display: 'Nova Scotia'
+          },
+          {
+            value: '0008',
+            display: 'Newfoundland and Labrador'
+          },
+          {
+            value: '0009',
+            display: 'New Brunswick'
+          },
+          {
+            value: '0010',
+            display: 'Prince Edward Island'
+          },
+          {
+            value: '0011',
+            display: 'Yukon'
+          },
+          {
+            value: '0012',
+            display: 'Northwest Territories'
+          },
+          {
+            value: '0013',
+            display: 'Nunavut'
+          },
+        ]
+
+        ngOnInit(): void {
+          this.form = new UntypedFormGroup({
+            displayOptionsTypeaheadMulti: new UntypedFormControl([]), // best to make your default an empty array for multiselects
           })
         }
       }

--- a/src/app/forms/multiselects/multiselects.component.html
+++ b/src/app/forms/multiselects/multiselects.component.html
@@ -24,6 +24,24 @@
   </demonstrator>
 </section>
 
+<section #section id="displayOptionsPicklistMulti" class="mb-5 mt-3">
+  <h3>Hide or disable selected items</h3>
+  <p>Use <code>[displaySelectionItems]</code> to hide or disable options that have already been selected.</p>
+  <demonstrator
+    [control]="form?.controls?.['displayOptionsPicklistMulti']" [htmlFile]="snippets?.displayOptionsPicklistMulti?.html"  [tsFile]="snippets?.displayOptionsPicklistMulti?.ts">
+    <ngds-picklist-input [control]="form?.controls?.['displayOptionsPicklistMulti']" [selectionListItems]="displayProvinceList" [multiselect]="true" [resetButton]="true" [selectAllButton]="true"
+    [displaySelectionItems]="'false'"
+    [label]="'Hide selected options'"
+    [placeholder]="'Select multiple'">
+    </ngds-picklist-input>
+    <ngds-picklist-input [control]="form?.controls?.['displayOptionsPicklistMulti']" [selectionListItems]="displayProvinceList" [multiselect]="true" [resetButton]="true" [selectAllButton]="true"
+    [displaySelectionItems]="'disabled'"
+    [label]="'Disable selected options'"
+    [placeholder]="'Select multiple'">
+    </ngds-picklist-input>
+  </demonstrator>
+</section>
+
 <section #section id="basicTypeaheadMulti" class="mb-5 mt-3">
   <h3>Basic typeahead multiselect</h3>
   <p>
@@ -44,6 +62,24 @@
     [control]="form?.controls?.['programmaticTypeaheadMulti']" [htmlFile]="snippets?.programmaticTypeaheadMulti?.html"  [tsFile]="snippets?.programmaticTypeaheadMulti?.ts">
     <button class="btn btn-primary my-2" (click)="programSet()">Set value</button>
     <ngds-typeahead-input [control]="form?.controls?.['programmaticTypeaheadMulti']" [selectionListItems]="displayProvinceList" [multiselect]="true" [resetButton]="true" [selectAllButton]="true"
+    [placeholder]="'Select multiple'">
+    </ngds-typeahead-input>
+  </demonstrator>
+</section>
+
+<section #section id="displayOptionsTypeaheadMulti" class="mb-5 mt-3">
+  <h3>Hide or disable selected items</h3>
+  <p>Use <code>[displaySelectionItems]</code> to hide or disable options that have already been selected.</p>
+  <demonstrator
+    [control]="form?.controls?.['displayOptionsTypeaheadMulti']" [htmlFile]="snippets?.displayOptionsTypeaheadMulti?.html"  [tsFile]="snippets?.displayOptionsTypeaheadMulti?.ts">
+    <ngds-typeahead-input [control]="form?.controls?.['displayOptionsTypeaheadMulti']" [selectionListItems]="displayProvinceList" [multiselect]="true" [resetButton]="true" [selectAllButton]="true"
+    [displaySelectionItems]="'false'"
+    [label]="'Hide selected options'"
+    [placeholder]="'Select multiple'">
+    </ngds-typeahead-input>
+    <ngds-typeahead-input [control]="form?.controls?.['displayOptionsTypeaheadMulti']" [selectionListItems]="displayProvinceList" [multiselect]="true" [resetButton]="true" [selectAllButton]="true"
+    [displaySelectionItems]="'disabled'"
+    [label]="'Disable selected options'"
     [placeholder]="'Select multiple'">
     </ngds-typeahead-input>
   </demonstrator>

--- a/src/app/forms/multiselects/multiselects.component.ts
+++ b/src/app/forms/multiselects/multiselects.component.ts
@@ -69,7 +69,7 @@ export class MultiselectsComponent implements OnInit, AfterViewInit {
       value: '0013',
       display: 'Nunavut'
     },
-  ]
+  ];
   @ViewChildren('section') entries: TemplateRef<any>;
 
   constructor(
@@ -80,9 +80,11 @@ export class MultiselectsComponent implements OnInit, AfterViewInit {
     this.form = new UntypedFormGroup({
       basicTypeaheadMulti: new UntypedFormControl(null),
       programmaticTypeaheadMulti: new UntypedFormControl(null),
+      displayOptionsTypeaheadMulti: new UntypedFormControl(null),
       basicPicklistMulti: new UntypedFormControl(null),
       programmaticPicklistMulti: new UntypedFormControl(null),
-    })
+      displayOptionsPicklistMulti: new UntypedFormControl(null),
+    });
     for (const control of Object.keys(this.form.controls)) {
       this.fields[control] = this.form.controls[control];
     }
@@ -97,7 +99,7 @@ export class MultiselectsComponent implements OnInit, AfterViewInit {
         list.push({
           href: item?.nativeElement?.id,
           title: titleIndex.innerText
-        })
+        });
       }
     }
     this.sidebarService.updateList(list);
@@ -125,7 +127,7 @@ export class MultiselectsComponent implements OnInit, AfterViewInit {
       if (value?.length > 3) {
         return { customValidator: "You can pick a max of 3 items." };
       }
-      return null
-    }
+      return null;
+    };
   }
 }

--- a/src/app/forms/picklists/picklist-snippets.ts
+++ b/src/app/forms/picklists/picklist-snippets.ts
@@ -84,13 +84,13 @@ export const snippets = {
   },
   customPicklist: {
     html: `
-    <ngds-picklist-input 
+    <ngds-picklist-input
       [control]="form?.controls?.['customPicklist']"
       [selectionListItems]="customSelectionItems"
       [placeholder]="'Make a selection'"
       [selectionListTemplate]="customOptionTemplate">
     </ngds-picklist-input>
-    
+
     <ng-template #customOptionTemplate let-data="data">
       <div class="mx-2 p-2 template-example">
         <h5>Custom HTML Option</h5>
@@ -116,7 +116,7 @@ export const snippets = {
           'value 1',
           { value: 'value 2', display: 'Item without template' },
           { value: 'value 3'},
-          { value: 'value 4', display: 'Item with custom template and display option'} 
+          { value: 'value 4', display: 'Item with custom template and display option'}
         ]
 
         ngOnInit(): void {
@@ -215,7 +215,7 @@ export const snippets = {
         <button ngdsInputAppend class="btn btn-warning">Button 3</button>
         <button ngdsInputAppend class="btn btn-danger">Button 4</button>
     </ngds-picklist-input>
-  
+
     <ngds-picklist-input
       [control]="form?.controls?.['inlinePicklist']"
       [resetButton]="true"
@@ -257,7 +257,7 @@ export const snippets = {
       background-color: aquamarine;
       color: purple;
     }
-    
+
     .custom-append {
       background-color: purple;
       color: aquamarine;
@@ -295,7 +295,7 @@ export const snippets = {
           }, 2500);
         }
 
-        changeTimer(nextSelectList) { 
+        changeTimer(nextSelectList) {
           setInterval(() => {
             this.currentChangeSelectList = nextSelectList;
           }, 5000);
@@ -305,39 +305,69 @@ export const snippets = {
   },
   autoCloseBehaviour: {
     html: `
-    <ngds-picklist-input [control]="form?.controls?.['changeSelectList']" [selectionListItems]="currentChangeSelectList"
-    [placeholder]="'Make a selection'">
+    <ngds-picklist-input
+      [control]="form?.controls?.['autoCloseBehaviour']"
+      [selectionListItems]="basicSelectionItems"
+      [autoCloseBehaviour]="'inside"
+      [placeholder]="'Make a selection'">
   </ngds-picklist-input>`,
     ts: `
     import { Component, OnInit } from '@angular/core';
     import { UntypedFormControl, UntypedFormGroup} from '@angular/forms';
 
     @Component({
-      selector: 'change-picklist'
-      export class ChangingPicklist implements OnInit {
+      selector: 'autoclose-dropdown'
+      export class AutoCloseDropdown implements OnInit {
         public form;
-
-        public changeSelectList1 = ['this option is only in list 1', 'this option is in both lists'];
-        public changeSelectList2 = ['this option is only in list 2', 'this option is in both lists'];
-        public currentChangeSelectList;
 
         ngOnInit(): void {
           this.form = new UntypedFormGroup({
-            changeSelectList: new UntypedFormControl(null),
+            autoCloseBehaviour: new UntypedFormControl(null),
           })
-
-          this.currentChangeSelectList = this.changeSelectList1;
-          this.changeTimer(this.changeSelectList1);
-          setTimeout(() => {
-            this.currentChangeSelectList = this.changeSelectList2;
-            this.changeTimer(this.changeSelectList2);
-          }, 2500);
         }
+      }
+    })`
+  },
+  displaySelectionItems: {
+    html: `
+    <ngds-picklist-input>
+      [control]="form?.controls?.['displaySelectionItems']"
+      [selectionListItems]="basicSelectionItems"
+      [displaySelectionItems]="'true'"
+      [label]="'True'"
+      [placeholder]="'Make a selection'">
+    </ngds-picklist-input>
 
-        changeTimer(nextSelectList) { 
-          setInterval(() => {
-            this.currentChangeSelectList = nextSelectList;
-          }, 5000);
+    <ngds-picklist-input>
+      [control]="form?.controls?.['displaySelectionItems']"
+      [selectionListItems]="basicSelectionItems"
+      [displaySelectionItems]="'false'"
+      [label]="'False'"
+      [placeholder]="'Make a selection'">
+    </ngds-picklist-input>
+
+    <ngds-picklist-input>
+      [control]="form?.controls?.['displaySelectionItems']"
+      [selectionListItems]="basicSelectionItems"
+      [displaySelectionItems]="'disabled'"
+      [label]="'Disabled'"
+      [placeholder]="'Make a selection'">
+    </ngds-picklist-input>`,
+    ts: `
+    import { Component, OnInit } from '@angular/core';
+    import { UntypedFormControl, UntypedFormGroup} from '@angular/forms';
+
+    @Component({
+      selector: 'display-selection-picklist'
+      export class ChangingPicklist implements OnInit {
+         public form;
+
+        public basicSelectionItems = ['value 1', 'value 2', 'value 3'];
+
+        ngOnInit(): void {
+          this.form = new UntypedFormGroup({
+            basicPicklist: new UntypedFormControl(null),
+          })
         }
       }
     })`

--- a/src/app/forms/picklists/picklists.component.html
+++ b/src/app/forms/picklists/picklists.component.html
@@ -113,9 +113,7 @@
   #customOptionTemplate
   let-data="data"
 >
-  <div
-    class="m-2 template-example"
-  >
+  <div class="m-2 template-example">
     <div><strong>Value:</strong> {{data?.value || data}}</div>
     <div><strong>Display:</strong> {{data?.display || '&lt;no display&gt;'}}</div>
     <span *ngIf="data?.display">This option will have a value of "<code>{{data?.value || data}}</code>" when picked.
@@ -358,16 +356,25 @@
 >
   <h3>Dropdown auto-close behaviour</h3>
   <p>
-    Having dynamic picklist options can have unwanted behaviour when the options list changes. By default, if an option
-    is selected and is in the new options list, the value of the input will not change. If the option is not in the new
-    options list, the control will reset.
+    Depending on where the user clicks, the dropdown can be tuned to respond differently using
+    <code>[autoCloseBehaviour]</code>. There are four options:
   </p>
+  <ul>
+    <li>
+      <strong>Inside</strong>: The dropdown is not closed if the input is clicked.
+    </li>
+    <li>
+      <strong>Outside</strong>: The dropdown is not closed if the input or the dropdown menu are clicked.
+    </li>
+    <li>
+      <strong>False</strong>: The dropdown is not closed if the menu is clicked.
+    </li>
+    <li>
+      <strong>True</strong>: The dropdown is always closed on click.
+    </li>
+  </ul>
   <p>
-    If you want the control to autoselect the first item in the new option list if it doesn't find a match, set
-    <code>[autoSelectFirstItem]="true"</code>.
-  </p>
-  <p>
-    The example below will switch between two different options lists every 2.5 seconds.
+    The default behaviour is <strong>inside</strong>.
   </p>
   <demonstrator
     [htmlFile]="snippets?.autoCloseBehaviour?.html"
@@ -410,17 +417,63 @@
       [placeholder]="'Make a selection'"
     >
     </ngds-picklist-input>
-    <div class="form-check form-switch mt-2">
-      <input
-        class="form-check-input"
-        type="checkbox"
-        id="flexSwitchAutoSelect"
-        (click)="autoSelectSwitch()"
-      >
-      <label
-        class="form-check-label"
-        for="flexSwitchAutoSelect"
-      >Toggle autoselect first item</label>
-    </div>
+  </demonstrator>
+</section>
+
+<section
+  #section
+  id="displaySelectionItems"
+  class="mb-5 mt-3"
+>
+  <h3>Selection list display behaviour</h3>
+  <p>
+    The display of the selection list can be controlled using <code>[displaySelectionItems]</code>. There are three
+    options:
+  </p>
+  <ul>
+    <li>
+      <strong>true</strong>: The selection list will always display all options.
+    </li>
+    <li>
+      <strong>false</strong>: The selection list will only display options that the user has not already selected.
+    </li>
+    <li>
+      <strong>disabled</strong>: The selection list will display all options, but the user will not be able to select
+      ones that are already selected.
+    </li>
+  </ul>
+  <demonstrator
+    [htmlFile]="snippets?.displaySelectionItems?.html"
+    [tsFile]="snippets?.displaySelectionItems?.ts"
+    [control]="form?.controls?.['displaySelectionItems']"
+  >
+    <ngds-picklist-input
+      [control]="form?.controls?.['displaySelectionItems']"
+      [displaySelectionItems]="'true'"
+      [label]="'True'"
+      [subLabel]="'The selection list will always display all options.'"
+      [selectionListItems]="basicSelectionItems"
+      [placeholder]="'Make a selection'"
+    >
+    </ngds-picklist-input>
+    <ngds-picklist-input
+      [control]="form?.controls?.['displaySelectionItems']"
+      [displaySelectionItems]="'false'"
+      [label]="'False'"
+      [subLabel]="'The selection list will only display options that the user has not already selected.'"
+      [selectionListItems]="basicSelectionItems"
+      [placeholder]="'Make a selection'"
+    >
+    </ngds-picklist-input>
+    <ngds-picklist-input
+      [control]="form?.controls?.['displaySelectionItems']"
+      [displaySelectionItems]="'disabled'"
+      [label]="'Disabled'"
+      [subLabel]="'The selection list will display all options, but the user will not be able to select
+      ones that are already selected.'"
+      [selectionListItems]="basicSelectionItems"
+      [placeholder]="'Make a selection'"
+    >
+    </ngds-picklist-input>
   </demonstrator>
 </section>

--- a/src/app/forms/picklists/picklists.component.ts
+++ b/src/app/forms/picklists/picklists.component.ts
@@ -61,6 +61,7 @@ export class PicklistsComponent implements OnInit, AfterViewInit {
         inlinePicklist: new UntypedFormControl(null),
         changeSelectList: new UntypedFormControl(null),
         autoCloseBehaviour: new UntypedFormControl(null),
+        displaySelectionItems: new UntypedFormControl(null),
       }
     )
     for (const control of Object.keys(this.form.controls)) {

--- a/src/app/forms/typeaheads/typeahead-snippets.ts
+++ b/src/app/forms/typeaheads/typeahead-snippets.ts
@@ -369,7 +369,7 @@ export const snippets = {
       [resetButton]="true"
       [selectionListTemplate]="customTemplate">
     </ngds-typeahead-input>
-    
+
     <ng-template #customTemplate let-matches="matches" let-query="query" let-typeaheadTemplateMethods>
       <ul class="custom-list-group">
         <li class="custom-list-group-item" *ngFor="let match of matches"
@@ -393,7 +393,7 @@ export const snippets = {
       selector: 'custom-template-typeahead'
       export class CustomTemplateTypeahead implements OnInit {
         public form;
-        
+
         @ViewChild('customTemplate') customTemplate: TemplateRef<any>;
 
         displayProvinceList = [
@@ -491,24 +491,24 @@ export const snippets = {
       overflow-y: scroll;
       background-color: aquamarine;
     }
-    
+
     .custom-list-group-item {
       padding: 0.5rem;
       background-color: purple;
       border: 1px solid lightgrey;
       border-radius: 5px;
       margin: 0.5rem;
-    
+
       &:hover {
         background-color: rgb(2, 83, 56);
       }
     }
-    
+
     .custom-highlight {
       font-weight: bold;
       color: goldenrod;
     }
-    
+
     .custom-no-highlight {
       color: skyblue;
     }
@@ -523,7 +523,7 @@ export const snippets = {
       [resetButton]="true"
       [selectionListTemplate]="customTemplate">
     </ngds-typeahead-input>
-    
+
     <ng-template #customTemplate let-matches="matches" let-query="query" let-typeaheadTemplateMethods>
       <ul class="custom-list-group">
         <li class="custom-list-group-item" *ngFor="let match of matches"
@@ -547,7 +547,7 @@ export const snippets = {
       selector: 'custom-template-typeahead'
       export class CustomTemplateTypeahead implements OnInit {
         public form;
-        
+
         @ViewChild('customTemplate') customTemplate: TemplateRef<any>;
 
         displayProvinceList = [
@@ -650,7 +650,7 @@ export const snippets = {
       selector: 'invalid-typeahead'
       export class InvalidTypeahead implements OnInit {
         public form;
-        
+
         displayProvinceList = [
           {
             value: '0001',
@@ -723,6 +723,86 @@ export const snippets = {
           }
         }
 
+`
+  },
+  displaySelectedTypeahead: {
+    html: `
+    <ngds-typeahead-input
+      [control]="form?.controls?.['displaySelectedTypeahead']"
+      [selectionListItems]="displayProvinceList"
+      [displaySelectionItems]="'false'"
+      [placeholder]="'Start typing...'"
+      [resetButton]="true">
+    </ngds-typeahead-input>`,
+    ts: `
+    import { Component } from '@angular/core';
+    import { UntypedFormControl, UntypedFormGroup} from '@angular/forms';
+
+    @Component({
+      selector: 'display-selected-typeahead'
+      export class DisplaySelectedTypeahead implements OnInit {
+        public form;
+
+        displayProvinceList = [
+          {
+            value: '0001',
+            display: 'British Columbia'
+          },
+          {
+            value: '0002',
+            display: 'Alberta'
+          },
+          {
+            value: '0003',
+            display: 'Saskatchewan'
+          },
+          {
+            value: '0004',
+            display: 'Manitoba'
+          },
+          {
+            value: '0005',
+            display: 'Ontario'
+          },
+          {
+            value: '0006',
+            display: 'Quebec'
+          },
+          {
+            value: '0007',
+            display: 'Nova Scotia'
+          },
+          {
+            value: '0008',
+            display: 'Newfoundland and Labrador'
+          },
+          {
+            value: '0009',
+            display: 'New Brunswick'
+          },
+          {
+            value: '0010',
+            display: 'Prince Edward Island'
+          },
+          {
+            value: '0011',
+            display: 'Yukon'
+          },
+          {
+            value: '0012',
+            display: 'Northwest Territories'
+          },
+          {
+            value: '0013',
+            display: 'Nunavut'
+          },
+        ]
+
+        ngOnInit(): void {
+          this.form = new UntypedFormGroup({
+            displaySelectedTypeahead: new UntypedFormControl(null),
+          })
+        }
 `
   }
 }

--- a/src/app/forms/typeaheads/typeaheads.component.html
+++ b/src/app/forms/typeaheads/typeaheads.component.html
@@ -1,8 +1,17 @@
 <h2>Typeaheads</h2>
-<section #section id="basicTypeahead" class="mb-5 mt-3">
+<section
+  #section
+  id="basicTypeahead"
+  class="mb-5 mt-3"
+>
   <h3>Basic Typeahead</h3>
   <p>
-    Provide the list of selection options as an array in <code>[selectionListItems]</code>, same as the picklist input. NGDS Forms Typeahead extends the functionality of the typeahead provided in <a href="https://valor-software.com/ngx-bootstrap/#/components/typeahead" target="_blank" rel="noopener">ngx-bootstrap</a>.
+    Provide the list of selection options as an array in <code>[selectionListItems]</code>, same as the picklist input.
+    NGDS Forms Typeahead extends the functionality of the typeahead provided in <a
+      href="https://valor-software.com/ngx-bootstrap/#/components/typeahead"
+      target="_blank"
+      rel="noopener"
+    >ngx-bootstrap</a>.
   </p>
   <p>
     Use <code>[adaptivePosition]="false"</code> to force the suggestions to dropdown.
@@ -12,49 +21,98 @@
     In the example below, search for a Canadian province or territory.
   </p>
   <demonstrator
-    [htmlFile]="snippets?.basicTypeahead?.html" [tsFile]="snippets?.basicTypeahead?.ts"
-    [control]="form?.controls?.['basicTypeahead']">
-    <ngds-typeahead-input [control]="form?.controls?.['basicTypeahead']" [selectionListItems]="simpleProvinceList"
-      [label]="'My typeahead label'" [subLabel]="'My typeahead sub-label'" [placeholder]="'My placeholder'" [resetButton]="true">
+    [htmlFile]="snippets?.basicTypeahead?.html"
+    [tsFile]="snippets?.basicTypeahead?.ts"
+    [control]="form?.controls?.['basicTypeahead']"
+  >
+    <ngds-typeahead-input
+      [control]="form?.controls?.['basicTypeahead']"
+      [selectionListItems]="simpleProvinceList"
+      [label]="'My typeahead label'"
+      [subLabel]="'My typeahead sub-label'"
+      [placeholder]="'My placeholder'"
+      [resetButton]="true"
+    >
     </ngds-typeahead-input>
   </demonstrator>
 </section>
 
-<section #section id="programmaticTypeahead" class="mb-5 mt-3">
+<section
+  #section
+  id="programmaticTypeahead"
+  class="mb-5 mt-3"
+>
   <h3>Set typeahead value programmatically</h3>
-  <demonstrator [htmlFile]="snippets?.programmaticTypeahead?.html" [tsFile]="snippets?.programmaticTypeahead?.ts"
-    [control]="form?.controls?.['programmaticTypeahead']">
-    <button class="btn btn-primary mb-2" (click)="programmaticSet()">Set value</button>
-    <ngds-typeahead-input [control]="form?.controls?.['programmaticTypeahead']" [selectionListItems]="displayProvinceList" [adaptivePosition]="false">
+  <demonstrator
+    [htmlFile]="snippets?.programmaticTypeahead?.html"
+    [tsFile]="snippets?.programmaticTypeahead?.ts"
+    [control]="form?.controls?.['programmaticTypeahead']"
+  >
+    <button
+      class="btn btn-primary mb-2"
+      (click)="programmaticSet()"
+    >Set value</button>
+    <ngds-typeahead-input
+      [control]="form?.controls?.['programmaticTypeahead']"
+      [selectionListItems]="displayProvinceList"
+      [adaptivePosition]="false"
+    >
     </ngds-typeahead-input>
   </demonstrator>
 </section>
 
-<section #section id="minLength" class="mb-5 mt-3">
+<section
+  #section
+  id="minLength"
+  class="mb-5 mt-3"
+>
   <h3>Minimum length prerequisite</h3>
   <p>
-    If your selection list has many items, you may want to limit the number that are suggested at a given time. Provide <code>[typeaheadMinLength]</code> to enforce a minimum length of characters before suggestions are shown.
+    If your selection list has many items, you may want to limit the number that are suggested at a given time. Provide
+    <code>[typeaheadMinLength]</code> to enforce a minimum length of characters before suggestions are shown.
   </p>
-  <demonstrator [htmlFile]="snippets?.minLength?.html" [tsFile]="snippets?.minLength?.ts"
-    [control]="form?.controls?.['minLength']">
-    <ngds-typeahead-input [control]="form?.controls?.['minLength']" [selectionListItems]="displayProvinceList" [typeaheadMinLength]="3" [label]="'Minimum of 3 characters before suggestions appear'" [placeholder]="'Type at least 3 characters...'" [adaptivePosition]="false" [resetButton]="true">
+  <demonstrator
+    [htmlFile]="snippets?.minLength?.html"
+    [tsFile]="snippets?.minLength?.ts"
+    [control]="form?.controls?.['minLength']"
+  >
+    <ngds-typeahead-input
+      [control]="form?.controls?.['minLength']"
+      [selectionListItems]="displayProvinceList"
+      [typeaheadMinLength]="3"
+      [label]="'Minimum of 3 characters before suggestions appear'"
+      [placeholder]="'Type at least 3 characters...'"
+      [adaptivePosition]="false"
+      [resetButton]="true"
+    >
     </ngds-typeahead-input>
   </demonstrator>
 </section>
 
-<section #section id="displayTypeahead" class="mb-5 mt-3">
+<section
+  #section
+  id="displayTypeahead"
+  class="mb-5 mt-3"
+>
   <h3>Typeahead with custom option text</h3>
   <p>
     If you want your options to have displays that differ from their values, provide your
     <code>[selectionListItems]</code> array as an array of the following type:
   </p>
   <pre><code [highlight]="'items: [{value: any, display: string}]'" [languages]="['typescript']"></code></pre>
-  <demonstrator [headerText]="'Basic typeahead'"
+  <demonstrator
+    [headerText]="'Basic typeahead'"
     [description]="'Provide the list of selection options as an array in [selectionListItems].'"
-    [htmlFile]="snippets?.displayTypeahead?.html" [tsFile]="snippets?.displayTypeahead?.ts"
-    [control]="form?.controls?.['displayTypeahead']">
-    <ngds-typeahead-input [control]="form?.controls?.['displayTypeahead']" [selectionListItems]="displayProvinceList"
-      [placeholder]="'Start typing...'" [resetButton]="true">
+    [htmlFile]="snippets?.displayTypeahead?.html"
+    [tsFile]="snippets?.displayTypeahead?.ts"
+    [control]="form?.controls?.['displayTypeahead']"
+  >
+    <ngds-typeahead-input
+      [control]="form?.controls?.['displayTypeahead']"
+      [selectionListItems]="displayProvinceList"
+      [placeholder]="'Start typing...'"
+      [resetButton]="true"
+    >
     </ngds-typeahead-input>
   </demonstrator>
 </section>
@@ -92,44 +150,141 @@
   </ul>
 </ng-template> -->
 
-<section #section id="disableTypeahead" class="mb-5 mt-3">
+<section
+  #section
+  id="disableTypeahead"
+  class="mb-5 mt-3"
+>
   <h3>Disabled and loading typeaheads</h3>
   <p>
     Disabled and loading state can be controlled with <code>[disabled]</code> and <code>[loadWhile]</code> attributes,
     respectively. You can also disable the control programmatically by calling <code>control.disable()</code>.
   </p>
-  <demonstrator [headerText]="'Basic typeahead'"
+  <demonstrator
+    [headerText]="'Basic typeahead'"
     [description]="'Provide the list of selection options as an array in [selectionListItems].'"
-    [htmlFile]="snippets?.disableTypeahead?.html" [tsFile]="snippets?.disableTypeahead?.ts"
-    [control]="form?.controls?.['disableTypeahead']">
-    <ngds-typeahead-input [control]="form?.controls?.['disableTypeahead']" [selectionListItems]="displayProvinceList" [disabled]="isDisabled" [loadWhile]="isLoading"
-      [placeholder]="'Start typing...'" [resetButton]="true">
+    [htmlFile]="snippets?.disableTypeahead?.html"
+    [tsFile]="snippets?.disableTypeahead?.ts"
+    [control]="form?.controls?.['disableTypeahead']"
+  >
+    <ngds-typeahead-input
+      [control]="form?.controls?.['disableTypeahead']"
+      [selectionListItems]="displayProvinceList"
+      [disabled]="isDisabled"
+      [loadWhile]="isLoading"
+      [placeholder]="'Start typing...'"
+      [resetButton]="true"
+    >
     </ngds-typeahead-input>
     <div class="form-check form-switch mt-2">
-      <input class="form-check-input" type="checkbox" id="flexSwitchDisabled" (click)="disabledSwitch()">
-      <label class="form-check-label" for="flexSwitchDisabled">Toggle disabled</label>
+      <input
+        class="form-check-input"
+        type="checkbox"
+        id="flexSwitchDisabled"
+        (click)="disabledSwitch()"
+      >
+      <label
+        class="form-check-label"
+        for="flexSwitchDisabled"
+      >Toggle disabled</label>
     </div>
     <div class="form-check form-switch mt-2">
-      <input class="form-check-input" type="checkbox" id="flexSwitchLoading" (click)="loadingSwitch()">
-      <label class="form-check-label" for="flexSwitchLoading">Toggle loading</label>
+      <input
+        class="form-check-input"
+        type="checkbox"
+        id="flexSwitchLoading"
+        (click)="loadingSwitch()"
+      >
+      <label
+        class="form-check-label"
+        for="flexSwitchLoading"
+      >Toggle loading</label>
     </div>
     <div class="form-check form-switch mt-2">
-      <input class="form-check-input" type="checkbox" id="flexSwitchProgram"
-        [checked]="form?.controls?.['disableTypeahead'].disabled" (click)="disableProgrammatically('disableTypeahead')">
-      <label class="form-check-label" for="flexSwitchProgram">Toggle disable programmatically</label>
+      <input
+        class="form-check-input"
+        type="checkbox"
+        id="flexSwitchProgram"
+        [checked]="form?.controls?.['disableTypeahead'].disabled"
+        (click)="disableProgrammatically('disableTypeahead')"
+      >
+      <label
+        class="form-check-label"
+        for="flexSwitchProgram"
+      >Toggle disable programmatically</label>
     </div>
   </demonstrator>
 </section>
 
-<section #section id="disableTypeahead" class="mb-5 mt-3">
+<section
+  #section
+  id="disableTypeahead"
+  class="mb-5 mt-3"
+>
   <h3>Invalid typeaheads</h3>
   <p>
-    NGDS picklists use Angular's prebuilt <code>Validation</code> capacities. You can use a prebuilt Validator or create a custom one. In the example below, only provinces are valid options.
+    NGDS picklists use Angular's prebuilt <code>Validation</code> capacities. You can use a prebuilt Validator or create
+    a custom one. In the example below, only provinces are valid options.
   </p>
   <demonstrator
-    [htmlFile]="snippets?.invalidTypeahead?.html" [tsFile]="snippets?.invalidTypeahead?.ts"
-    [control]="form?.controls?.['invalidTypeahead']">
-    <ngds-typeahead-input [control]="form?.controls?.['invalidTypeahead']" [selectionListItems]="displayProvinceList" [placeholder]="'Start typing...'" [resetButton]="true">
+    [htmlFile]="snippets?.invalidTypeahead?.html"
+    [tsFile]="snippets?.invalidTypeahead?.ts"
+    [control]="form?.controls?.['invalidTypeahead']"
+  >
+    <ngds-typeahead-input
+      [control]="form?.controls?.['invalidTypeahead']"
+      [selectionListItems]="displayProvinceList"
+      [placeholder]="'Start typing...'"
+      [resetButton]="true"
+    >
     </ngds-typeahead-input>
   </demonstrator>
 </section>
+
+<!-- <section
+  #section
+  id="displaySelectedTypeahead"
+  class="mb-5 mt-3"
+>
+  <h3>Selected items display behaviour</h3>
+  <p>
+    The display of the selection list can be controlled using <code>[displaySelectionItems]</code>. There are three
+    options:
+  </p>
+  <ul>
+    <li>
+      <strong>true</strong>: The selection list will always display all options.
+    </li>
+    <li>
+      <strong>false</strong>: The selection list will only display options that the user has not already selected.
+    </li>
+    <li>
+      <strong>disabled</strong>: The selection list will display all options, but the user will not be able to select
+      ones that are already selected.
+    </li>
+  </ul>
+  <demonstrator
+    [htmlFile]="snippets?.displaySelectedTypeahead?.html"
+    [tsFile]="snippets?.displaySelectedTypeahead?.ts"
+    [control]="form?.controls?.['displaySelectedTypeahead']"
+  >
+    <ngds-typeahead-input
+      [control]="form?.controls?.['displaySelectedTypeahead']"
+      [selectionListItems]="displayProvinceList"
+      [placeholder]="'Start typing...'"
+      [displaySelectionItems]="'false'"
+      [label]="'Hide selected options'"
+      [resetButton]="true"
+    >
+    </ngds-typeahead-input>
+    <ngds-typeahead-input
+      [control]="form?.controls?.['displaySelectedTypeahead']"
+      [selectionListItems]="displayProvinceList"
+      [placeholder]="'Start typing...'"
+      [displaySelectionItems]="'disabled'"
+      [label]="'Disable selected options'"
+      [resetButton]="true"
+    >
+    </ngds-typeahead-input>
+  </demonstrator>
+</section> -->

--- a/src/app/forms/typeaheads/typeaheads.component.ts
+++ b/src/app/forms/typeaheads/typeaheads.component.ts
@@ -113,6 +113,7 @@ export class TypeaheadsComponent implements OnInit {
         minLength: new UntypedFormControl(''),
         disableTypeahead: new UntypedFormControl(''),
         invalidTypeahead: new UntypedFormControl('', [this.customValidator()]),
+        displaySelectedTypeahead: new UntypedFormControl(''),
       }
     )
     for (const control of Object.keys(this.form.controls)) {


### PR DESCRIPTION
You can now add `[displaySelectionItems] = 'true' | 'false' | 'disabled'` to hide/disable already selected options from picklists and multiselects.

- true: show all options
- false: hide selected options
- disabled: show all options but disable selected options.