### PR TITLE
Clearing several issues

### DIFF
--- a/projects/ngds-forms/assets/styles/styles.scss
+++ b/projects/ngds-forms/assets/styles/styles.scss
@@ -55,7 +55,7 @@ $active-invalid-outline: red;
     color: black;
 
     &:hover {
-      background-color: var(--bs-gray-300) !important;
+      background-color: var(--bs-gray-400) !important;
 
       &:not(.in-range) {
         border-radius: 2rem;
@@ -77,13 +77,18 @@ $active-invalid-outline: red;
       background-color: var(--bs-gray-500) !important;
 
       &:hover {
-        background-color: var(--bs-gray-400) !important;
+        background-color: var(--bs-gray-500) !important;
       }
     }
 
     &.in-range {
       background-color: var(--bs-gray-200);
       font-weight: bold;
+
+      &.invalid-range {
+        color: var(--bs-gray-500);
+        background-color: var(--bs-gray-300) !important;
+      }
     }
   }
 }

--- a/projects/ngds-forms/src/lib/components/input-types/date-input/calendar/calendar-manager/calendar-manager.component.html
+++ b/projects/ngds-forms/src/lib/components/input-types/date-input/calendar/calendar-manager/calendar-manager.component.html
@@ -1,22 +1,49 @@
 <div class="d-flex row">
   <div class="col-auto overflow-auto">
     <!-- Render 1 calendar for datepicker -->
-    <ngds-calendar [calendarConfig]="startCalendar" [disabledDatesFn]="disabledDatesFn" [dateRange]="dateRange"
-      [displayDepth]="displayDepth.value" [selectedDate]="selectedDate" [hoverDate]="hoverDate"
-      [selectedEndDate]="selectedEndDate" [disabled]="disabled" [allowDisabledInRange]="allowDisabledInRange"
-      (changeDate)="updateCalendarConfig($event, startCalendar)" [minDisplayDepth]="minDisplayDepth"
-      (changeMonth)="setMonthToValue($event, startCalendar)" (changeDepth)="toggleDepth($event)"
-      (changeYear)="setYearToValue($event, startCalendar)" (changeHoverDate)="updateHoverDate($event)"
-      (changeDisplay)="changeDisplayByValue($event)" (clearDates)="clearDates.emit()"></ngds-calendar>
+    <ngds-calendar
+      [calendarConfig]="startCalendar"
+      [disabledDatesFn]="disabledDatesFn"
+      [dateRange]="dateRange"
+      [displayDepth]="displayDepth.value"
+      [selectedDate]="selectedDate"
+      [hoverDate]="hoverDate"
+      [selectedEndDate]="selectedEndDate"
+      [disabled]="disabled"
+      [allowDisabledInRange]="allowDisabledInRange"
+      (changeDate)="updateCalendarConfig($event, startCalendar)"
+      [minDisplayDepth]="minDisplayDepth"
+      (changeMonth)="setMonthToValue($event, startCalendar)"
+      (changeDepth)="toggleDepth($event)"
+      (changeYear)="setYearToValue($event, startCalendar)"
+      (changeHoverDate)="updateHoverDate($event)"
+      (changeDisplay)="changeDisplayByValue($event)"
+      (clearDates)="clearDates.emit()"
+    ></ngds-calendar>
   </div>
-  <div *ngIf="dateRange && !hideSecondCalendar" class="col-auto overflow-auto">
+  <div
+    *ngIf="dateRange && !hideSecondCalendar"
+    class="col-auto overflow-auto"
+  >
     <!-- Render 2 calendars for rangepicker -->
-    <ngds-calendar [calendarConfig]="endCalendar" [disabledDatesFn]="disabledDatesFn" [dateRange]="dateRange"
-      [displayDepth]="displayDepth.value" [selectedDate]="selectedDate" [hoverDate]="hoverDate"
-      [minDisplayDepth]="minDisplayDepth" [selectedEndDate]="selectedEndDate" [disabled]="disabled"
-      [allowDisabledInRange]="allowDisabledInRange" (changeDate)="updateCalendarConfig($event, endCalendar)"
-      (changeMonth)="setMonthToValue($event, endCalendar)" (changeDepth)="toggleDepth($event)"
-      (changeYear)="setYearToValue($event, endCalendar)" (changeHoverDate)="updateHoverDate($event)"
-      (changeDisplay)="changeDisplayByValue($event)" (clearDates)="clearDates.emit()"></ngds-calendar>
+    <ngds-calendar
+      [calendarConfig]="endCalendar"
+      [disabledDatesFn]="disabledDatesFn"
+      [dateRange]="dateRange"
+      [displayDepth]="displayDepth.value"
+      [selectedDate]="selectedDate"
+      [hoverDate]="hoverDate"
+      [minDisplayDepth]="minDisplayDepth"
+      [selectedEndDate]="selectedEndDate"
+      [disabled]="disabled"
+      [allowDisabledInRange]="allowDisabledInRange"
+      (changeDate)="updateCalendarConfig($event, endCalendar)"
+      (changeMonth)="setMonthToValue($event, endCalendar)"
+      (changeDepth)="toggleDepth($event)"
+      (changeYear)="setYearToValue($event, endCalendar)"
+      (changeHoverDate)="updateHoverDate($event)"
+      (changeDisplay)="changeDisplayByValue($event)"
+      (clearDates)="clearDates.emit()"
+    ></ngds-calendar>
   </div>
 </div>

--- a/projects/ngds-forms/src/lib/components/input-types/date-input/calendar/calendar-manager/calendar-manager.component.ts
+++ b/projects/ngds-forms/src/lib/components/input-types/date-input/calendar/calendar-manager/calendar-manager.component.ts
@@ -53,6 +53,9 @@ export class NgdsCalendarManager implements OnInit {
   // The maximum number of days that can be selected in a rangepicker. Default (0) is unlimited days.
   @Input() maxRange: number = 0;
 
+  // The minimum number of days that can be selected in a rangepicker. Default (0) is zero days.
+  @Input() minRange: number = 0;
+
   // Whether or not the datepicker is disabled.
   @Input() disabled: boolean = false;
 
@@ -248,7 +251,8 @@ export class NgdsCalendarManager implements OnInit {
       year: date.year,
       weeks: weeks,
       years: this.getYears(date.year),
-      maxRange: this.maxRange
+      maxRange: this.maxRange,
+      minRange: this.minRange
     });
     this.displayChange.emit();
     if (emitChange) {

--- a/projects/ngds-forms/src/lib/components/input-types/date-input/date-input.component.html
+++ b/projects/ngds-forms/src/lib/components/input-types/date-input/date-input.component.html
@@ -103,6 +103,7 @@
     [dateRange]="dateRange"
     [minDisplayDepth]="minMode"
     [maxRange]="maxRange"
+    [minRange]="minRange"
     [selectedDate]="selectedDate.value"
     [selectedEndDate]="selectedEndDate.value"
     [allowDisabledInRange]="allowDisabledInRange"

--- a/projects/ngds-forms/src/lib/components/input-types/date-input/date-input.component.ts
+++ b/projects/ngds-forms/src/lib/components/input-types/date-input/date-input.component.ts
@@ -1,5 +1,4 @@
-import { AfterViewInit, ChangeDetectorRef, Component, ElementRef, EventEmitter, Input, Output, Renderer2, ViewChild } from '@angular/core';
-import { NgdsInput } from '../ngds-input.component';
+import { ChangeDetectorRef, Component, EventEmitter, Input, Output, Renderer2 } from '@angular/core';
 import { DateTime, Duration } from 'luxon';
 import { BehaviorSubject } from 'rxjs';
 import { ValidationErrors, ValidatorFn } from '@angular/forms';
@@ -36,6 +35,9 @@ export class NgdsDateInput extends NgdsDropdown {
 
   // The maximum allowable length of a selected range. No limit if set to 0.
   @Input() maxRange: number = 0;
+
+  // The minimum allowable length of a selected range. No limit if set to 0.
+  @Input() minRange: number = 0;
 
   // The string used in the input display to separate the start and end display strings of a range.
   @Input() rangeSeparator: string = 'to';
@@ -79,7 +81,6 @@ export class NgdsDateInput extends NgdsDropdown {
   }
 
   afterDropdownInitFn(): void {
-   
     if (!this.dateDisplayFormat) {
       this.dateDisplayFormat = this.dateFormat;
     }

--- a/projects/ngds-forms/src/lib/components/input-types/ngds-input.component.ts
+++ b/projects/ngds-forms/src/lib/components/input-types/ngds-input.component.ts
@@ -103,7 +103,7 @@ export class NgdsInput implements OnInit, OnDestroy {
 
   // If true, disables the control and shows a loading spinner.
   @Input() set loadWhile(isLoading: boolean) {
-    this.updateDisabledState(isLoading);
+    this.updateDisabledState(isLoading, true);
     this._loading.next(isLoading);
   }
 
@@ -273,9 +273,7 @@ export class NgdsInput implements OnInit, OnDestroy {
       if (!Array.isArray(activeSelection)) {
         activeSelection = [activeSelection];
       }
-      console.log('activeSelection:', activeSelection);
       const activeSelectionValues = activeSelection.map((item) => item?.value || item);
-      console.log('activeSelectionValues:', activeSelectionValues);
       if (this.displaySelectionItems === 'disabled') {
         this._displayedSelectionListItems.next(formattedSelectionListItems.map((item) => {
           if (activeSelectionValues.indexOf(item.value) > -1) {
@@ -286,7 +284,6 @@ export class NgdsInput implements OnInit, OnDestroy {
           }
           return item;
         }));
-        console.log('this.displayedSelectionListItems:', this.displayedSelectionListItems);
       } else if (this.displaySelectionItems === 'false') {
         // If displaySelectionItems is 'false', we don't want to show any selection items.
         this._displayedSelectionListItems.next(formattedSelectionListItems.filter((item) =>
@@ -296,7 +293,11 @@ export class NgdsInput implements OnInit, OnDestroy {
     }
   }
 
-  updateDisabledState(state) {
+  updateDisabledState(state, checkStateFirst = false) {
+    if (!state && checkStateFirst && this.isDisabled === true) {
+      return; // If enabling from loadWhile but the disabled state is active, do nothing.
+    }
+    // If state is true, disable the control, otherwise enable it.
     if (state === true) {
       setTimeout(() => {
         this.control?.disable();

--- a/projects/ngds-forms/src/lib/components/input-types/number-input/number-input.component.ts
+++ b/projects/ngds-forms/src/lib/components/input-types/number-input/number-input.component.ts
@@ -77,7 +77,7 @@ export class NgdsNumberInput extends NgdsInput implements AfterViewInit {
   }
 
   set displayValue(value) {
-    if (value) {
+    if (!isNaN(value)) {
       // We cannot safely represent all numbers
       if (this.checkNumberRepresentation(value)) {
         let next = String(value).match(this.regex)?.[0];
@@ -330,7 +330,7 @@ export class NgdsNumberInput extends NgdsInput implements AfterViewInit {
       this.displayValue = Number(value).toFixed(this.decimalPlaces);
     }
     else if (alwaysSet) {
-      this.displayValue = value;
+      this.displayValue = Number(value);
     }
     if (this.valueAsString) {
       this.setControlValue(this.displayValue);

--- a/src/app/forms/datepicker/datepickers/datepickers.component.html
+++ b/src/app/forms/datepicker/datepickers/datepickers.component.html
@@ -259,7 +259,8 @@
   </demonstrator>
 </section>
 
-<section #section id="hideOnClickDatepicker" class="mb-5 mt-3">
+<!-- Improved by ngds-dropdown -->
+<!-- <section #section id="hideOnClickDatepicker" class="mb-5 mt-3">
   <h3>Persist datepicker on click</h3>
   <p>
     By default, the calendar will hide itself when a date is selected. To keep the calendar open after a date is
@@ -270,7 +271,7 @@
     <ngds-date-input [control]="form?.controls?.['hideOnSelectDatepicker']" [resetButton]="true" [hideOnSelect]="false">
     </ngds-date-input>
   </demonstrator>
-</section>
+</section> -->
 
 <section #section id="timezones" class="mb-5 mt-3">
   <h3>Timezones</h3>

--- a/src/app/forms/datepicker/rangepickers/rangepicker-snippets.ts
+++ b/src/app/forms/datepicker/rangepickers/rangepicker-snippets.ts
@@ -126,7 +126,8 @@ export const snippets = {
       [control]="form?.controls?.['maxRangeRangepicker']"
       [dateRange]="true"
       [resetButton]="true"
-      [maxRange]="5">
+      [maxRange]="4">
+      <!-- OR [minRange]="4" -->
     </ngds-date-input>`,
     ts: `
     import { Component, OnInit } from '@angular/core';

--- a/src/app/forms/datepicker/rangepickers/rangepickers.component.html
+++ b/src/app/forms/datepicker/rangepickers/rangepickers.component.html
@@ -2,7 +2,9 @@
 </h2>
 <section>
   <p>
-    NGDS Forms Rangepicker leverages <a href="https://moment.github.io/luxon/#/">luxon</a> and <a href="https://popper.js.org/">popper.js</a>.
+    NGDS Forms Rangepicker leverages <a href="https://moment.github.io/luxon/#/">luxon</a> and <a
+      href="https://popper.js.org/"
+    >popper.js</a>.
   </p>
   <pre class="border rounded px-3 py-1"><code class="p-0" [highlight]="luxonCode"></code></pre>
   <p>
@@ -17,7 +19,11 @@
 </pre>
 
 
-<section #section id="basicRangepicker" class="mb-5 mt-3">
+<section
+  #section
+  id="basicRangepicker"
+  class="mb-5 mt-3"
+>
   <h3>Basic Rangepicker</h3>
   <p>
     Rangepicker functionality is very similar to NGDS Datepicker. To turn a datepicker into a rangepicker, add the
@@ -34,146 +40,329 @@
       Datepicker</a> is recommended.
   </p>
   <p>
-    If the second date selected in the rangepicker is chronologically before the first, the rangepicker will reorient the selections such that the chronologically earlier date always comes first - you cannot select a negative range.
+    If the second date selected in the rangepicker is chronologically before the first, the rangepicker will reorient
+    the selections such that the chronologically earlier date always comes first - you cannot select a negative range.
   </p>
-  <demonstrator [headerText]="'Basic datepicker'" [htmlFile]="snippets?.basicRangepicker?.html"
-    [tsFile]="snippets?.basicRangepicker?.ts" [control]="form?.controls?.['basicRangepicker']">
-    <ngds-date-input [control]="form?.controls?.['basicRangepicker']" [label]="'My rangepicker label'"
-      [subLabel]="'My rangepicker sub-label'" [placeholder]="'My placeholder'" [dateRange]="true">
+  <demonstrator
+    [headerText]="'Basic datepicker'"
+    [htmlFile]="snippets?.basicRangepicker?.html"
+    [tsFile]="snippets?.basicRangepicker?.ts"
+    [control]="form?.controls?.['basicRangepicker']"
+  >
+    <ngds-date-input
+      [control]="form?.controls?.['basicRangepicker']"
+      [label]="'My rangepicker label'"
+      [subLabel]="'My rangepicker sub-label'"
+      [placeholder]="'My placeholder'"
+      [dateRange]="true"
+    >
     </ngds-date-input>
   </demonstrator>
 </section>
 
-<section #section id="programmaticRangepicker" class="mb-5 mt-3">
+<section
+  #section
+  id="programmaticRangepicker"
+  class="mb-5 mt-3"
+>
   <h3>Programmatic rangepicker</h3>
   <p>
     The example below selects the range between <code>today</code> and <code>tomorrow</code> (UTC) by default. When you
     reset the input, it will again select the same range.
   </p>
-  <demonstrator [htmlFile]="snippets?.programmaticRangepicker?.html" [tsFile]="snippets?.programmaticRangepicker?.ts"
-    [control]="form?.controls?.['programmaticRangepicker']">
-    <ngds-date-input [control]="form?.controls?.['programmaticRangepicker']" [dateRange]="true" [resetButton]="true">
+  <demonstrator
+    [htmlFile]="snippets?.programmaticRangepicker?.html"
+    [tsFile]="snippets?.programmaticRangepicker?.ts"
+    [control]="form?.controls?.['programmaticRangepicker']"
+  >
+    <ngds-date-input
+      [control]="form?.controls?.['programmaticRangepicker']"
+      [dateRange]="true"
+      [resetButton]="true"
+    >
     </ngds-date-input>
   </demonstrator>
 </section>
 
-<section #section id="inlineRangepicker" class="mb-5 mt-3">
+<section
+  #section
+  id="inlineRangepicker"
+  class="mb-5 mt-3"
+>
   <h3>Inline rangepicker</h3>
   <p>
     The rangepicker calendars are dropdown by default. You can display the rangepicker inline by passing
     <code>[inline]="true"</code>
   </p>
-  <demonstrator [htmlFile]="snippets?.inlineRangepicker?.html" [tsFile]="snippets?.inlineRangepicker?.ts"
-    [control]="form?.controls?.['inlineRangepicker']">
-    <ngds-date-input [control]="form?.controls?.['inlineRangepicker']" [dateRange]="true" [resetButton]="true"
-      [inline]="true">
+  <demonstrator
+    [htmlFile]="snippets?.inlineRangepicker?.html"
+    [tsFile]="snippets?.inlineRangepicker?.ts"
+    [control]="form?.controls?.['inlineRangepicker']"
+  >
+    <ngds-date-input
+      [control]="form?.controls?.['inlineRangepicker']"
+      [dateRange]="true"
+      [resetButton]="true"
+      [inline]="true"
+    >
     </ngds-date-input>
   </demonstrator>
 </section>
 
-<section #section id="disabledRangepicker" class="mb-5 mt-3">
+<section
+  #section
+  id="disabledRangepicker"
+  class="mb-5 mt-3"
+>
   <h3>Disabled rangepicker</h3>
   <p>
     Disabled and loading state can be controlled with <code>[disabled]</code> and <code>[loadWhile]</code> attributes,
     respectively. You can also disable the control programmatically by calling <code>control.disable()</code>.
   </p>
-  <demonstrator [htmlFile]="snippets?.disabledRangepicker.html" [tsFile]="snippets?.disabledRangepicker.ts"
-    [control]="form?.controls?.['disabledRangepicker']">
-    <ngds-date-input [control]="form?.controls?.['disabledRangepicker']" [dateRange]="true" [resetButton]="true" [inline]="true" [disabled]="isDisabled" [loadWhile]="isLoading">
+  <demonstrator
+    [htmlFile]="snippets?.disabledRangepicker.html"
+    [tsFile]="snippets?.disabledRangepicker.ts"
+    [control]="form?.controls?.['disabledRangepicker']"
+  >
+    <ngds-date-input
+      [control]="form?.controls?.['disabledRangepicker']"
+      [dateRange]="true"
+      [resetButton]="true"
+      [inline]="true"
+      [disabled]="isDisabled"
+      [loadWhile]="isLoading"
+    >
     </ngds-date-input>
     <div class="form-check form-switch mt-2">
-      <input class="form-check-input" type="checkbox" id="flexSwitchDisabled" (click)="disabledSwitch()">
-      <label class="form-check-label" for="flexSwitchDisabled">Toggle disabled</label>
+      <input
+        class="form-check-input"
+        type="checkbox"
+        id="flexSwitchDisabled"
+        (click)="disabledSwitch()"
+      >
+      <label
+        class="form-check-label"
+        for="flexSwitchDisabled"
+      >Toggle disabled</label>
     </div>
     <div class="form-check form-switch mt-2">
-      <input class="form-check-input" type="checkbox" id="flexSwitchLoading" (click)="loadingSwitch()">
-      <label class="form-check-label" for="flexSwitchLoading">Toggle loading</label>
+      <input
+        class="form-check-input"
+        type="checkbox"
+        id="flexSwitchLoading"
+        (click)="loadingSwitch()"
+      >
+      <label
+        class="form-check-label"
+        for="flexSwitchLoading"
+      >Toggle loading</label>
     </div>
     <div class="form-check form-switch mt-2">
-      <input class="form-check-input" type="checkbox" id="flexSwitchProgram"
+      <input
+        class="form-check-input"
+        type="checkbox"
+        id="flexSwitchProgram"
         [checked]="form?.controls?.['disabledRangepicker'].disabled"
-        (click)="disableProgrammatically('disabledRangepicker')">
-      <label class="form-check-label" for="flexSwitchProgram">Toggle disable programmatically</label>
+        (click)="disableProgrammatically('disabledRangepicker')"
+      >
+      <label
+        class="form-check-label"
+        for="flexSwitchProgram"
+      >Toggle disable programmatically</label>
     </div>
   </demonstrator>
 </section>
 
-<section #section id="maxRangeRangepicker" class="mb-5 mt-3">
-  <h3>Maximum range rangepicker</h3>
+<section
+  #section
+  id="maxRangeRangepicker"
+  class="mb-5 mt-3"
+>
+  <h3>Maximum and minimum range rangepicker</h3>
   <p>
-    The maximum range of dates can be limited by using <code>[maxRange]</code>. In the example below, a maximum range of 5 days can be selected.
+    The allowable range of dates can be limited by using <code>[minRange]</code> and <code>[maxRange]</code>. The values
+    given for <code>[minRange]</code> and <code>[maxRange]</code> should be the number of days NOT including the start
+    date that are permissible in the date range. For example, if <code>[minRange]</code> is 3, there will be 4 days in
+    the range - the start date, plus three days. A <code>[minRange]</code> or <code>[maxRange]</code> of 0 will allow
+    you to select the same day for the start and end dates.
   </p>
-  <demonstrator [htmlFile]="snippets?.maxRangeRangepicker?.html" [tsFile]="snippets?.maxRangeRangepicker?.ts"
-    [control]="form?.controls?.['maxRangeRangepicker']">
-    <ngds-date-input [control]="form?.controls?.['maxRangeRangepicker']" [dateRange]="true" [resetButton]="true" [maxRange]="5">
+  <p>
+    Another way to think about this is that the <code>[minRange]</code> and <code>[maxRange]</code> values are the
+    number of nights in the range.
+  </p>
+  <p>
+    Selecting outside the permissible range will reset your first date selection.
+  </p>
+  <demonstrator
+    [htmlFile]="snippets?.maxRangeRangepicker?.html"
+    [tsFile]="snippets?.maxRangeRangepicker?.ts"
+    [control]="form?.controls?.['maxRangeRangepicker']"
+  >
+    <ngds-date-input
+      [control]="form?.controls?.['maxRangeRangepicker']"
+      [dateRange]="true"
+      [resetButton]="true"
+      [label]="'Maximum range'"
+      [subLabel]="'This field allows a maximum of 5 days in the range (maxRange 4)'"
+      [maxRange]="4"
+    >
     </ngds-date-input>
+    <ngds-date-input
+      [control]="form?.controls?.['minRangeRangepicker']"
+      [dateRange]="true"
+      [resetButton]="true"
+      [label]="'Minimum range'"
+      [subLabel]="'This field allows a minimum of 5 days in the range (minRange 4)'"
+      [minRange]="4"
+    >
+    </ngds-date-input>
+
   </demonstrator>
 </section>
 
-<section #section id="disabledDatesRangepicker" class="mb-5 mt-3">
+<section
+  #section
+  id="disabledDatesRangepicker"
+  class="mb-5 mt-3"
+>
   <h3>Custom disabled dates</h3>
   <p>
-    Disabled date functionality works analogously to NGDS Datepicker's <a href="forms/datepicker#customDisabledDatepicker">disabled dates</a>. NGDS Rangepicker has access to <code>[minDate]</code>, <code>[maxDate]</code>, and <code>[customDisableDatesCallback]</code> properties.
+    Disabled date functionality works analogously to NGDS Datepicker's <a
+      href="forms/datepicker#customDisabledDatepicker"
+    >disabled dates</a>. NGDS Rangepicker has access to <code>[minDate]</code>, <code>[maxDate]</code>, and
+    <code>[customDisableDatesCallback]</code> properties.
   </p>
   <p>
-    By default, you cannot select a range that includes a disabled date. If you need to allow disabled dates to be included in a selected range, use <code>[allowDisabledInRange]="true"</code>.
+    By default, you cannot select a range that includes a disabled date. If you need to allow disabled dates to be
+    included in a selected range, use <code>[allowDisabledInRange]="true"</code>.
   </p>
   <p>
     In the example below, the 15th day of each month is disabled.
   </p>
-  <demonstrator [htmlFile]="snippets?.disabledDatesRangepicker?.html" [tsFile]="snippets?.disabledDatesRangepicker?.ts"
-    [control]="form?.controls?.['disabledDatesRangepicker']">
-    <ngds-date-input [control]="form?.controls?.['disabledDatesRangepicker']" [label]="'Disabled dates disallowed'" [dateRange]="true" [resetButton]="true" [customDisabledDatesCallback]="customDisabledDatesCallback">
+  <demonstrator
+    [htmlFile]="snippets?.disabledDatesRangepicker?.html"
+    [tsFile]="snippets?.disabledDatesRangepicker?.ts"
+    [control]="form?.controls?.['disabledDatesRangepicker']"
+  >
+    <ngds-date-input
+      [control]="form?.controls?.['disabledDatesRangepicker']"
+      [label]="'Disabled dates disallowed'"
+      [dateRange]="true"
+      [resetButton]="true"
+      [customDisabledDatesCallback]="customDisabledDatesCallback"
+    >
     </ngds-date-input>
   </demonstrator>
   <div class="mt-2"></div>
-  <demonstrator [htmlFile]="snippets?.allowDisabledDatesRangepicker?.html" [tsFile]="snippets?.allowDisabledDatesRangepicker?.ts"
-    [control]="form?.controls?.['allowDisabledDatesRangepicker']">
-    <ngds-date-input [control]="form?.controls?.['allowDisabledDatesRangepicker']" [label]="'Disabled dates allowed'" [dateRange]="true" [resetButton]="true" [customDisabledDatesCallback]="customDisabledDatesCallback" [allowDisabledInRange]="true">
+  <demonstrator
+    [htmlFile]="snippets?.allowDisabledDatesRangepicker?.html"
+    [tsFile]="snippets?.allowDisabledDatesRangepicker?.ts"
+    [control]="form?.controls?.['allowDisabledDatesRangepicker']"
+  >
+    <ngds-date-input
+      [control]="form?.controls?.['allowDisabledDatesRangepicker']"
+      [label]="'Disabled dates allowed'"
+      [dateRange]="true"
+      [resetButton]="true"
+      [customDisabledDatesCallback]="customDisabledDatesCallback"
+      [allowDisabledInRange]="true"
+    >
     </ngds-date-input>
   </demonstrator>
 </section>
 
-<section #section id="invalidRangepicker" class="mb-5 mt-3">
+<section
+  #section
+  id="invalidRangepicker"
+  class="mb-5 mt-3"
+>
   <h3>Invalid rangepicker</h3>
   <p>
-    If you need to allow the user to select dates but reflect the validity of that date, leveraging control validation works similarly to other input types. In the example below, the selected range is invalid if it includes the 15th of any month.
+    If you need to allow the user to select dates but reflect the validity of that date, leveraging control validation
+    works similarly to other input types. In the example below, the selected range is invalid if it includes the 15th of
+    any month.
   </p>
-  <demonstrator [htmlFile]="snippets?.invalidRangepicker?.html" [tsFile]="snippets?.invalidRangepicker?.ts"
-    [control]="form?.controls?.['invalidRangepicker']">
-    <ngds-date-input [control]="form?.controls?.['invalidRangepicker']" [dateRange]="true" [resetButton]="true">
+  <demonstrator
+    [htmlFile]="snippets?.invalidRangepicker?.html"
+    [tsFile]="snippets?.invalidRangepicker?.ts"
+    [control]="form?.controls?.['invalidRangepicker']"
+  >
+    <ngds-date-input
+      [control]="form?.controls?.['invalidRangepicker']"
+      [dateRange]="true"
+      [resetButton]="true"
+    >
     </ngds-date-input>
   </demonstrator>
 </section>
 
-<section #section id="valueFormatRangepicker" class="mb-5 mt-3">
+<section
+  #section
+  id="valueFormatRangepicker"
+  class="mb-5 mt-3"
+>
   <h3>Formatting</h3>
   <p>
-    NGDS's Rangepicker follows the same value/display formatting rules as the <a href="forms/datepicker#valueFormatDatepicker">Datepicker</a>. The default value/display format is YYYY-MM-DD. Refer to the Datepicker documentation for more details.
+    NGDS's Rangepicker follows the same value/display formatting rules as the <a
+      href="forms/datepicker#valueFormatDatepicker"
+    >Datepicker</a>. The default value/display format is YYYY-MM-DD. Refer to the Datepicker documentation for more
+    details.
   </p>
   <p>
-    The display can be customised to change the string that separates the start and end dates by changing <code>[rangeSeparator]</code>. By default, <code>[rangeSeparator]="'to'"</code>.
+    The display can be customised to change the string that separates the start and end dates by changing
+    <code>[rangeSeparator]</code>. By default, <code>[rangeSeparator]="'to'"</code>.
   </p>
-  <demonstrator [htmlFile]="snippets?.valueFormatRangepicker.html" [tsFile]="snippets?.valueFormatRangepicker.ts"
-    [control]="form?.controls?.['valueFormatRangepicker']">
-    <ngds-date-input [control]="form?.controls?.['valueFormatRangepicker']" [dateRange]="true" [resetButton]="true" [dateFormat]="'DD'" [label]="'Formatting control value'">
+  <demonstrator
+    [htmlFile]="snippets?.valueFormatRangepicker.html"
+    [tsFile]="snippets?.valueFormatRangepicker.ts"
+    [control]="form?.controls?.['valueFormatRangepicker']"
+  >
+    <ngds-date-input
+      [control]="form?.controls?.['valueFormatRangepicker']"
+      [dateRange]="true"
+      [resetButton]="true"
+      [dateFormat]="'DD'"
+      [label]="'Formatting control value'"
+    >
     </ngds-date-input>
   </demonstrator>
   <div class="mt-2"></div>
-  <demonstrator [htmlFile]="snippets?.displayFormatRangepicker.html" [tsFile]="snippets?.displayFormatRangepicker.ts"
-    [control]="form?.controls?.['displayFormatRangepicker']">
-    <ngds-date-input [control]="form?.controls?.['displayFormatRangepicker']" [dateRange]="true" [resetButton]="true" [dateDisplayFormat]="'DDD'" [label]="'Formatting control display'">
+  <demonstrator
+    [htmlFile]="snippets?.displayFormatRangepicker.html"
+    [tsFile]="snippets?.displayFormatRangepicker.ts"
+    [control]="form?.controls?.['displayFormatRangepicker']"
+  >
+    <ngds-date-input
+      [control]="form?.controls?.['displayFormatRangepicker']"
+      [dateRange]="true"
+      [resetButton]="true"
+      [dateDisplayFormat]="'DDD'"
+      [label]="'Formatting control display'"
+    >
     </ngds-date-input>
   </demonstrator>
   <div class="mt-2"></div>
-  <demonstrator [htmlFile]="snippets?.rangeSeparatorRangepicker.html" [tsFile]="snippets?.rangeSeparatorRangepicker.ts"
-    [control]="form?.controls?.['rangeSeparatorRangepicker']">
-    <ngds-date-input [control]="form?.controls?.['rangeSeparatorRangepicker']" [dateRange]="true" [resetButton]="true" [rangeSeparator]="'===>'" [label]="'Formatting rangeSeparator'">
+  <demonstrator
+    [htmlFile]="snippets?.rangeSeparatorRangepicker.html"
+    [tsFile]="snippets?.rangeSeparatorRangepicker.ts"
+    [control]="form?.controls?.['rangeSeparatorRangepicker']"
+  >
+    <ngds-date-input
+      [control]="form?.controls?.['rangeSeparatorRangepicker']"
+      [dateRange]="true"
+      [resetButton]="true"
+      [rangeSeparator]="'===>'"
+      [label]="'Formatting rangeSeparator'"
+    >
     </ngds-date-input>
   </demonstrator>
 </section>
 
-<section #section id="timezones" class="mb-5 mt-3">
+<section
+  #section
+  id="timezones"
+  class="mb-5 mt-3"
+>
   <h3>Timezones</h3>
   <p>
     See the <a href="forms/datepicker#timezones">Datepicker</a> timezone examples for more details.
@@ -181,69 +370,153 @@
   <pre class="border rounded px-3 py-1">
     <code class="p-0">Current browser time: {{now?.value?.toFormat('DDDD TT (z)') }}</code>
   </pre>
-  <demonstrator [htmlFile]="snippets?.timezoneUTC?.html"
-    [tsFile]="snippets?.timezoneUTC?.ts" [control]="form?.controls?.['timezoneUTC']">
-    <ngds-date-input [control]="form?.controls?.['timezoneUTC']" [resetButton]="true" [timezone]="'UTC'" [dateDisplayFormat]="'X (z)'" [dateFormat]="'yyyy-LL-dd, TT'" [label]="'UTC'" [dateRange]="true">
+  <demonstrator
+    [htmlFile]="snippets?.timezoneUTC?.html"
+    [tsFile]="snippets?.timezoneUTC?.ts"
+    [control]="form?.controls?.['timezoneUTC']"
+  >
+    <ngds-date-input
+      [control]="form?.controls?.['timezoneUTC']"
+      [resetButton]="true"
+      [timezone]="'UTC'"
+      [dateDisplayFormat]="'X (z)'"
+      [dateFormat]="'yyyy-LL-dd, TT'"
+      [label]="'UTC'"
+      [dateRange]="true"
+    >
     </ngds-date-input>
   </demonstrator>
   <div class="mt-2"></div>
-  <demonstrator [htmlFile]="snippets?.timezoneNiue?.html"
-    [tsFile]="snippets?.timezoneNiue?.ts" [control]="form?.controls?.['timezoneNiue']">
-    <ngds-date-input [control]="form?.controls?.['timezoneNiue']" [resetButton]="true" [timezone]="'Pacific/Niue'" [dateDisplayFormat]="'X (z)'" [dateFormat]="'yyyy-LL-dd, TT'" [label]="'Pacific/Niue (UTC-11)'" [dateRange]="true">
+  <demonstrator
+    [htmlFile]="snippets?.timezoneNiue?.html"
+    [tsFile]="snippets?.timezoneNiue?.ts"
+    [control]="form?.controls?.['timezoneNiue']"
+  >
+    <ngds-date-input
+      [control]="form?.controls?.['timezoneNiue']"
+      [resetButton]="true"
+      [timezone]="'Pacific/Niue'"
+      [dateDisplayFormat]="'X (z)'"
+      [dateFormat]="'yyyy-LL-dd, TT'"
+      [label]="'Pacific/Niue (UTC-11)'"
+      [dateRange]="true"
+    >
     </ngds-date-input>
   </demonstrator>
   <div class="mt-2"></div>
-  <demonstrator [htmlFile]="snippets?.timezoneKiritimati?.html"
-    [tsFile]="snippets?.timezoneKiritimati?.ts" [control]="form?.controls?.['timezoneKiritimati']">
-    <ngds-date-input [control]="form?.controls?.['timezoneKiritimati']" [resetButton]="true"  [timezone]="'Pacific/Kiritimati'" [dateDisplayFormat]="'X (z)'" [dateFormat]="'yyyy-LL-dd, TT'" [label]="'Pacific/Kiritimati (UTC+14)'" [dateRange]="true">
+  <demonstrator
+    [htmlFile]="snippets?.timezoneKiritimati?.html"
+    [tsFile]="snippets?.timezoneKiritimati?.ts"
+    [control]="form?.controls?.['timezoneKiritimati']"
+  >
+    <ngds-date-input
+      [control]="form?.controls?.['timezoneKiritimati']"
+      [resetButton]="true"
+      [timezone]="'Pacific/Kiritimati'"
+      [dateDisplayFormat]="'X (z)'"
+      [dateFormat]="'yyyy-LL-dd, TT'"
+      [label]="'Pacific/Kiritimati (UTC+14)'"
+      [dateRange]="true"
+    >
     </ngds-date-input>
   </demonstrator>
 </section>
 
-<section #section id="displayDepth" class="mb-5 mt-3">
+<section
+  #section
+  id="displayDepth"
+  class="mb-5 mt-3"
+>
   <h3>Minimum display mode</h3>
   <p>
     See the <a href="forms/datepicker#displayDepth">Datepicker</a> display mode examples for more details.
   </p>
-  <demonstrator [htmlFile]="snippets?.minModeMonth?.html" [tsFile]="snippets?.minModeMonth?.ts"
-    [control]="form?.controls?.['minModeMonth']">
-    <ngds-date-input [control]="form?.controls?.['minModeMonth']" [resetButton]="true" [minMode]="1"
-      [dateDisplayFormat]="'LLLL, yyyy'" [label]="'Month (minMode 1)'" [dateRange]="true">
+  <demonstrator
+    [htmlFile]="snippets?.minModeMonth?.html"
+    [tsFile]="snippets?.minModeMonth?.ts"
+    [control]="form?.controls?.['minModeMonth']"
+  >
+    <ngds-date-input
+      [control]="form?.controls?.['minModeMonth']"
+      [resetButton]="true"
+      [minMode]="1"
+      [dateDisplayFormat]="'LLLL, yyyy'"
+      [label]="'Month (minMode 1)'"
+      [dateRange]="true"
+    >
     </ngds-date-input>
   </demonstrator>
   <div class="mt-2"></div>
-  <demonstrator [htmlFile]="snippets?.minModeYear?.html" [tsFile]="snippets?.minModeYear?.ts"
-    [control]="form?.controls?.['minModeYear']">
-    <ngds-date-input [control]="form?.controls?.['minModeYear']" [resetButton]="true" [minMode]="2"
-      [dateDisplayFormat]="'yyyy'" [label]="'Year (minMode 2)'" [dateRange]="true">
+  <demonstrator
+    [htmlFile]="snippets?.minModeYear?.html"
+    [tsFile]="snippets?.minModeYear?.ts"
+    [control]="form?.controls?.['minModeYear']"
+  >
+    <ngds-date-input
+      [control]="form?.controls?.['minModeYear']"
+      [resetButton]="true"
+      [minMode]="2"
+      [dateDisplayFormat]="'yyyy'"
+      [label]="'Year (minMode 2)'"
+      [dateRange]="true"
+    >
     </ngds-date-input>
   </demonstrator>
 </section>
 
-<section #section id="hideSecondCalendar" class="mb-5 mt-3">
+<section
+  #section
+  id="hideSecondCalendar"
+  class="mb-5 mt-3"
+>
   <h3>Show only 1 calendar</h3>
   <p>
     To hide the second rangepicker calendar, set <code>[hideSecondCalendar]="true"</code>.
   </p>
-  <demonstrator [htmlFile]="snippets?.hideSecondCalendar?.html" [tsFile]="snippets?.hideSecondCalendar?.ts"
-    [control]="form?.controls?.['hideSecondCalendar']">
-    <ngds-date-input [control]="form?.controls?.['hideSecondCalendar']" [dateRange]="true" [resetButton]="true" [hideSecondCalendar]="true">
+  <demonstrator
+    [htmlFile]="snippets?.hideSecondCalendar?.html"
+    [tsFile]="snippets?.hideSecondCalendar?.ts"
+    [control]="form?.controls?.['hideSecondCalendar']"
+  >
+    <ngds-date-input
+      [control]="form?.controls?.['hideSecondCalendar']"
+      [dateRange]="true"
+      [resetButton]="true"
+      [hideSecondCalendar]="true"
+    >
     </ngds-date-input>
   </demonstrator>
 </section>
 
-<section #section id="fixedRangeSize" class="mb-5 mt-3">
+<section
+  #section
+  id="fixedRangeSize"
+  class="mb-5 mt-3"
+>
   <h3>Autoselect range by start date</h3>
   <p>
-    You can enforce an exact range to be selected with<code>[fixedRangeSize]="duration"</code>, where <code>duration</code> is a <code>luxon</code> Duration. When a date selection is made, the date is assumed to be the start of the range and the end date is automatically picked based on the provided Duration. Note that the Duration is added to the selected date down to the millisecond, so a Duration of 7 days will likely include 8 days (7 plus the start date) and will show as such in the calendar display.
+    You can enforce an exact range to be selected with<code>[fixedRangeSize]="duration"</code>, where
+    <code>duration</code> is a <code>luxon</code> Duration. When a date selection is made, the date is assumed to be the
+    start of the range and the end date is automatically picked based on the provided Duration. Note that the Duration
+    is added to the selected date down to the millisecond, so a Duration of 7 days will likely include 8 days (7 plus
+    the start date) and will show as such in the calendar display.
   </p>
   <p>The provided example automatically selects a 7 day range starting with the date selected.</p>
   <p>
-    See the <code>luxon</code>&nbsp;<a href="https://moment.github.io/luxon/api-docs/index.html#duration">Duration</a> documetation for more information.
+    See the <code>luxon</code>&nbsp;<a href="https://moment.github.io/luxon/api-docs/index.html#duration">Duration</a>
+    documetation for more information.
   </p>
-  <demonstrator [htmlFile]="snippets?.fixedRangeSize?.html" [tsFile]="snippets?.fixedRangeSize?.ts"
-    [control]="form?.controls?.['fixedRangeSize']">
-    <ngds-date-input [control]="form?.controls?.['fixedRangeSize']" [dateRange]="true" [resetButton]="true" [fixedRangeSize]="duration">
+  <demonstrator
+    [htmlFile]="snippets?.fixedRangeSize?.html"
+    [tsFile]="snippets?.fixedRangeSize?.ts"
+    [control]="form?.controls?.['fixedRangeSize']"
+  >
+    <ngds-date-input
+      [control]="form?.controls?.['fixedRangeSize']"
+      [dateRange]="true"
+      [resetButton]="true"
+      [fixedRangeSize]="duration"
+    >
     </ngds-date-input>
   </demonstrator>
 </section>

--- a/src/app/forms/datepicker/rangepickers/rangepickers.component.ts
+++ b/src/app/forms/datepicker/rangepickers/rangepickers.component.ts
@@ -34,6 +34,7 @@ export class RangepickersComponent {
       inlineRangepicker: new UntypedFormControl(null),
       disabledRangepicker: new UntypedFormControl(null),
       maxRangeRangepicker: new UntypedFormControl(null),
+      minRangeRangepicker: new UntypedFormControl(null),
       disabledDatesRangepicker: new UntypedFormControl(null),
       allowDisabledDatesRangepicker: new UntypedFormControl(null),
       invalidRangepicker: new UntypedFormControl(null, [this.customValidator()]),

--- a/src/app/forms/numbers/numbers.component.html
+++ b/src/app/forms/numbers/numbers.component.html
@@ -1,4 +1,5 @@
-<h2>Number Inputs <div class="badge bg-primary">beta</div></h2>
+<h2>Number Inputs <div class="badge bg-primary">beta</div>
+</h2>
 <p>
   Numerical inputs can be notoriously complicated to implement, and typically enforce many formatting rules and
   restrictions. Therefore, NGDS-Forms number inputs remain relatively simplistic in the behaviour they can achieve.
@@ -7,93 +8,194 @@
   For complex numerical inputs, it may be advisable to create a custom input that extends the base
   <code>NgdsInput</code> component (<a
     href="https://github.com/digitalspace/ngds-toolkit/blob/master/projects/ngds-forms/src/lib/components/input-types/ngds-input.component.ts"
-    target="_blank" rel="noopener">view on Github</a>).
+    target="_blank"
+    rel="noopener"
+  >view on Github</a>).
 </p>
-<section #section id="basicNumberEntry" class="mb-5 mt-3">
+<section
+  #section
+  id="basicNumberEntry"
+  class="mb-5 mt-3"
+>
   <h3>Basic numerical entry</h3>
   <p>
-    Number formatting is enforced by regular expression and by Javascript number representation limitations. By default, the following rules are enforced:
+    Number formatting is enforced by regular expression and by Javascript number representation limitations. By default,
+    the following rules are enforced:
   </p>
   <ul>
     <li>Only digits, 1 decimal point, and 1 minus sign allowed.</li>
     <li>The minus sign can only be placed at the beginning of the input.</li>
     <li>Number must be within Javascript's <code>MIN_SAFE_INTEGER</code> and <code>MAX_SAFE_INTEGER</code>.</li>
-    <li>At most 17 digits in length (16 if integer). If the input cannot be cast as a Javascript <code>number</code>, the input will not be registered.</li>
+    <li>At most 17 digits in length (16 if integer). If the input cannot be cast as a Javascript <code>number</code>,
+      the input will not be registered.</li>
   </ul>
-  <demonstrator [htmlFile]="snippets?.basicNumber?.html" [tsFile]="snippets?.basicNumber?.ts"
-    [control]="form?.controls?.['basicNumber']">
-    <ngds-number-input [control]="form?.controls?.['basicNumber']" [label]="'My input label'"
-      [subLabel]="'My input sub-label'" [placeholder]="'My placeholder'" [resetButton]="true">
+  <demonstrator
+    [htmlFile]="snippets?.basicNumber?.html"
+    [tsFile]="snippets?.basicNumber?.ts"
+    [control]="form?.controls?.['basicNumber']"
+  >
+    <ngds-number-input
+      [control]="form?.controls?.['basicNumber']"
+      [label]="'My input label'"
+      [subLabel]="'My input sub-label'"
+      [placeholder]="'My placeholder'"
+      [resetButton]="true"
+    >
     </ngds-number-input>
   </demonstrator>
 </section>
 
-<section #section id="disabledInput" class="mb-5 mt-3">
+<section
+  #section
+  id="disabledInput"
+  class="mb-5 mt-3"
+>
   <h3>Disabled number input</h3>
   <p>
     Use the toggle to enable/disable the control. You can use the <code>[disabled]</code> attribute to bind to a boolean
     or function that evaluates to a boolean. This will set the state of <code>control.enabled</code> and
     <code>control.disabled</code>.
   </p>
-  <demonstrator [htmlFile]="snippets?.disabledNumber?.html" [tsFile]="snippets?.disabledNumber?.ts"
-    [control]="form?.controls?.['disabledNumber']">
-    <ngds-number-input [control]="form?.controls?.['disabledNumber']" [resetButton]="true" [disabled]="isDisabled"
-      [loadWhile]="isLoading">
+  <demonstrator
+    [htmlFile]="snippets?.disabledNumber?.html"
+    [tsFile]="snippets?.disabledNumber?.ts"
+    [control]="form?.controls?.['disabledNumber']"
+  >
+    <ngds-number-input
+      [control]="form?.controls?.['disabledNumber']"
+      [resetButton]="true"
+      [disabled]="isDisabled"
+      [loadWhile]="isLoading"
+    >
     </ngds-number-input>
     <div class="form-check form-switch mt-2">
-      <input class="form-check-input" type="checkbox" id="flexSwitchDisabled" (click)="disabledSwitch()">
-      <label class="form-check-label" for="flexSwitchDisabled">Toggle disabled</label>
+      <input
+        class="form-check-input"
+        type="checkbox"
+        id="flexSwitchDisabled"
+        (click)="disabledSwitch()"
+      >
+      <label
+        class="form-check-label"
+        for="flexSwitchDisabled"
+      >Toggle disabled</label>
     </div>
     <div class="form-check form-switch mt-2">
-      <input class="form-check-input" type="checkbox" id="flexSwitchLoading" (click)="loadingSwitch()">
-      <label class="form-check-label" for="flexSwitchLoading">Toggle loading</label>
+      <input
+        class="form-check-input"
+        type="checkbox"
+        id="flexSwitchLoading"
+        (click)="loadingSwitch()"
+      >
+      <label
+        class="form-check-label"
+        for="flexSwitchLoading"
+      >Toggle loading</label>
     </div>
     <div class="form-check form-switch mt-2">
-      <input class="form-check-input" type="checkbox" id="flexSwitchProgram"
-        [checked]="form?.controls?.['disabledNumber'].disabled" (click)="disableProgrammatically('disabledNumber')">
-      <label class="form-check-label" for="flexSwitchProgram">Toggle disable programmatically</label>
+      <input
+        class="form-check-input"
+        type="checkbox"
+        id="flexSwitchProgram"
+        [checked]="form?.controls?.['disabledNumber'].disabled"
+        (click)="disableProgrammatically('disabledNumber')"
+      >
+      <label
+        class="form-check-label"
+        for="flexSwitchProgram"
+      >Toggle disable programmatically</label>
     </div>
   </demonstrator>
 </section>
 
-<section #section id="validation" class="mb-5 mt-3">
+<section
+  #section
+  id="validation"
+  class="mb-5 mt-3"
+>
   <h3>Number validation</h3>
   <p>
-    Use the toggle to enable/disable the control. You can use the <code>[disabled]</code> attribute to bind to a boolean
-    or function that evaluates to a boolean. This will set the state of <code>control.enabled</code> and
-    <code>control.disabled</code>.
+    Angular's <code>Validators</code> can be used to validate number inputs. Use <code>Validators.max()</code> and
+    <code>Validators.min()</code> to set maximum and minimum values for the input. Custom validators can also be used.
   </p>
-  <demonstrator [htmlFile]="snippets?.maxNumber?.html" [tsFile]="snippets?.maxNumber?.ts"
-    [control]="form?.controls?.['maxNumber']">
-    <ngds-number-input [control]="form?.controls?.['maxNumber']" [label]="'Maximum'">
+  <p>
+    In the examples below, different validators are used:
+  </p>
+  <ul>
+    <li>
+      <strong>Maximum </strong> <code>Validators.max(25)</code> - The input value cannot exceed 25.
+    </li>
+    <li>
+      <strong>Minimum </strong> <code>Validators.min(25)</code> - The input value cannot be less than 25.
+    </li>
+    <li>
+      <strong>Custom </strong> <code>customValidator()</code> - The input value cannot be exactly 40.
+    </li>
+  </ul>
+  <demonstrator
+    [htmlFile]="snippets?.maxNumber?.html"
+    [tsFile]="snippets?.maxNumber?.ts"
+    [control]="form?.controls?.['maxNumber']"
+  >
+    <ngds-number-input
+      [control]="form?.controls?.['maxNumber']"
+      [label]="'Maximum'"
+    >
     </ngds-number-input>
   </demonstrator>
-  <demonstrator [htmlFile]="snippets?.minNumber?.html" [tsFile]="snippets?.minNumber?.ts"
-    [control]="form?.controls?.['minNumber']">
-    <ngds-number-input [control]="form?.controls?.['minNumber']" [label]="'Minimum'">
+  <demonstrator
+    [htmlFile]="snippets?.minNumber?.html"
+    [tsFile]="snippets?.minNumber?.ts"
+    [control]="form?.controls?.['minNumber']"
+  >
+    <ngds-number-input
+      [control]="form?.controls?.['minNumber']"
+      [label]="'Minimum'"
+    >
     </ngds-number-input>
   </demonstrator>
-  <demonstrator [htmlFile]="snippets?.customNumberValidator?.html" [tsFile]="snippets?.customNumberValidator?.ts"
-    [control]="form?.controls?.['customNumberValidator']">
-    <ngds-number-input [control]="form?.controls?.['customNumberValidator']" [label]="'Custom validation'"
-      [subLabel]="'This input value cannot be 40.'">
+  <demonstrator
+    [htmlFile]="snippets?.customNumberValidator?.html"
+    [tsFile]="snippets?.customNumberValidator?.ts"
+    [control]="form?.controls?.['customNumberValidator']"
+  >
+    <ngds-number-input
+      [control]="form?.controls?.['customNumberValidator']"
+      [label]="'Custom validation'"
+      [subLabel]="'This input value cannot be 40.'"
+    >
     </ngds-number-input>
   </demonstrator>
 </section>
 
-<section #section id="enforcePositive" class="mb-5 mt-3">
+<section
+  #section
+  id="enforcePositive"
+  class="mb-5 mt-3"
+>
   <h3>Enforce positive numbers</h3>
   <p>
     Set <code>[allowNegative]="false"</code> to restrict entry to positive numbers.
   </p>
-  <demonstrator [htmlFile]="snippets?.positiveOnly?.html" [tsFile]="snippets?.positiveOnly?.ts"
-    [control]="form?.controls?.['positiveOnly']">
-    <ngds-number-input [control]="form?.controls?.['positiveOnly']" [allowNegative]="false" [resetButton]="true">
+  <demonstrator
+    [htmlFile]="snippets?.positiveOnly?.html"
+    [tsFile]="snippets?.positiveOnly?.ts"
+    [control]="form?.controls?.['positiveOnly']"
+  >
+    <ngds-number-input
+      [control]="form?.controls?.['positiveOnly']"
+      [allowNegative]="false"
+      [resetButton]="true"
+    >
     </ngds-number-input>
   </demonstrator>
 </section>
 
-<section #section id="decimalPlaces" class="mb-5 mt-3">
+<section
+  #section
+  id="decimalPlaces"
+  class="mb-5 mt-3"
+>
   <h3>Integers and decimal places</h3>
   <p>
     The <code>[decimalPlaces]</code> property can be used to limit the number of decimal places in the entry. By default
@@ -105,36 +207,65 @@
   <p>
     Using <code>[decimalPlaces]=">0"</code> enforces the provided number of decimal places.
   </p>
-  <demonstrator [htmlFile]="snippets?.integer?.html" [tsFile]="snippets?.integer?.ts"
-    [control]="form?.controls?.['integer']">
-    <ngds-number-input [control]="form?.controls?.['integer']" [resetButton]="true" [label]="'Integer'"
-      [decimalPlaces]="0">
+  <demonstrator
+    [htmlFile]="snippets?.integer?.html"
+    [tsFile]="snippets?.integer?.ts"
+    [control]="form?.controls?.['integer']"
+  >
+    <ngds-number-input
+      [control]="form?.controls?.['integer']"
+      [resetButton]="true"
+      [label]="'Integer'"
+      [decimalPlaces]="0"
+    >
     </ngds-number-input>
   </demonstrator>
-  <demonstrator [htmlFile]="snippets?.twoDecimalPlaces?.html" [tsFile]="snippets?.twoDecimalPlaces?.ts"
-    [control]="form?.controls?.['twoDecimalPlaces']">
-    <ngds-number-input [control]="form?.controls?.['twoDecimalPlaces']" [resetButton]="true"
-      [label]="'Two Decimal Places'" [decimalPlaces]="2">
+  <demonstrator
+    [htmlFile]="snippets?.twoDecimalPlaces?.html"
+    [tsFile]="snippets?.twoDecimalPlaces?.ts"
+    [control]="form?.controls?.['twoDecimalPlaces']"
+  >
+    <ngds-number-input
+      [control]="form?.controls?.['twoDecimalPlaces']"
+      [resetButton]="true"
+      [label]="'Two Decimal Places'"
+      [decimalPlaces]="2"
+    >
     </ngds-number-input>
   </demonstrator>
 </section>
 
-<section #section id="padDecimals" class="mb-5 mt-3">
+<section
+  #section
+  id="padDecimals"
+  class="mb-5 mt-3"
+>
   <h3>Pad decimal places</h3>
   <p>
     Setting <code>[padDecimals]="true"</code> will format the entered number to the number of decimal places specified
     in <code>[decimalPlaces]</code> when the control loses focus. In the example below,
     <code>[decimalPlaces]="3"</code>.
   </p>
-  <demonstrator [htmlFile]="snippets?.padDecimals?.html" [tsFile]="snippets?.padDecimals?.ts"
-    [control]="form?.controls?.['padDecimals']">
-    <ngds-number-input [control]="form?.controls?.['padDecimals']" [resetButton]="true" [padDecimals]="true"
-      [decimalPlaces]="3">
+  <demonstrator
+    [htmlFile]="snippets?.padDecimals?.html"
+    [tsFile]="snippets?.padDecimals?.ts"
+    [control]="form?.controls?.['padDecimals']"
+  >
+    <ngds-number-input
+      [control]="form?.controls?.['padDecimals']"
+      [resetButton]="true"
+      [padDecimals]="true"
+      [decimalPlaces]="3"
+    >
     </ngds-number-input>
   </demonstrator>
 </section>
 
-<section #section id="increment" class="mb-5 mt-3">
+<section
+  #section
+  id="increment"
+  class="mb-5 mt-3"
+>
   <h3>Scroll and button increment</h3>
   <p>
     Allow a user to increment and decrement the value of the input using the mouse scroll wheel by setting
@@ -146,31 +277,62 @@
     Note that <code>[incrementValue]</code> must be greater than or equal to the smallest number that can be represented
     with the number of decimal places allowed for the input.
   </p>
-  <demonstrator [htmlFile]="snippets?.increment?.html" [tsFile]="snippets?.increment?.ts"
-    [control]="form?.controls?.['increment']">
-    <ngds-number-input [control]="form?.controls?.['increment']" [label]="'Increment by 1'" [resetButton]="true"
-      [showIncrements]="true" [mouseScrollIncrement]="true">
+  <demonstrator
+    [htmlFile]="snippets?.increment?.html"
+    [tsFile]="snippets?.increment?.ts"
+    [control]="form?.controls?.['increment']"
+  >
+    <ngds-number-input
+      [control]="form?.controls?.['increment']"
+      [label]="'Increment by 1'"
+      [resetButton]="true"
+      [showIncrements]="true"
+      [mouseScrollIncrement]="true"
+    >
     </ngds-number-input>
   </demonstrator>
-  <demonstrator [htmlFile]="snippets?.increment2?.html" [tsFile]="snippets?.increment2?.ts"
-    [control]="form?.controls?.['increment2']">
-    <ngds-number-input [control]="form?.controls?.['increment2']" [resetButton]="true"
-      [label]="'Increment by 0.02, no negatives, pad decimals'" [showIncrements]="true" [mouseScrollIncrement]="true"
-      [incrementValue]="0.02" [decimalPlaces]="2" [allowNegative]="false" [padDecimals]="true">
+  <demonstrator
+    [htmlFile]="snippets?.increment2?.html"
+    [tsFile]="snippets?.increment2?.ts"
+    [control]="form?.controls?.['increment2']"
+  >
+    <ngds-number-input
+      [control]="form?.controls?.['increment2']"
+      [resetButton]="true"
+      [label]="'Increment by 0.02, no negatives, pad decimals'"
+      [showIncrements]="true"
+      [mouseScrollIncrement]="true"
+      [incrementValue]="0.02"
+      [decimalPlaces]="2"
+      [allowNegative]="false"
+      [padDecimals]="true"
+    >
     </ngds-number-input>
   </demonstrator>
 </section>
 
-<section #section id="asString" class="mb-5 mt-3">
+<section
+  #section
+  id="asString"
+  class="mb-5 mt-3"
+>
   <h3>Number as String</h3>
   <p>
     To represent the number as a string exactly as it is shown in the input, set <code>[valueAsString]="true"</code>. No
     formatting to number type will occur when the input value changes.
   </p>
-  <demonstrator [htmlFile]="snippets?.asString?.html" [tsFile]="snippets?.asString?.ts"
-    [control]="form?.controls?.['asString']">
-    <ngds-number-input [control]="form?.controls?.['asString']" [resetButton]="true" [decimalPlaces]="4"
-      [padDecimals]="true" [valueAsString]="true">
+  <demonstrator
+    [htmlFile]="snippets?.asString?.html"
+    [tsFile]="snippets?.asString?.ts"
+    [control]="form?.controls?.['asString']"
+  >
+    <ngds-number-input
+      [control]="form?.controls?.['asString']"
+      [resetButton]="true"
+      [decimalPlaces]="4"
+      [padDecimals]="true"
+      [valueAsString]="true"
+    >
     </ngds-number-input>
   </demonstrator>
 </section>

--- a/src/app/forms/text-input/text-input.component.html
+++ b/src/app/forms/text-input/text-input.component.html
@@ -1,35 +1,62 @@
 <h2>Text Inputs</h2>
-<section #section id="basicTextEntry" class="mb-5 mt-3">
+<section
+  #section
+  id="basicTextEntry"
+  class="mb-5 mt-3"
+>
   <h3>Basic text entry</h3>
   <p>
     At a minimum, you must provide every NGDS input with an Angular <code>AbstractControl</code> or derivative. All
-    other attributes are optional. Provide <code>[label]</code>, <code>[subLabel]</code>, and <code>[placeholder]</code> attributes for input labelling.
+    other attributes are optional. Provide <code>[label]</code>, <code>[subLabel]</code>, and <code>[placeholder]</code>
+    attributes for input labelling.
   </p>
   <p>
-    If you wish to use your own input, you can use <code>&lt;ngds-input-header&gt;</code> to match the label styling of NGDS forms.
+    If you wish to use your own input, you can use <code>&lt;ngds-input-header&gt;</code> to match the label styling of
+    NGDS forms.
   </p>
-  <demonstrator [htmlFile]="snippets?.basicText?.html" [tsFile]="snippets?.basicText?.ts"
-    [control]="form?.controls?.['basicText']">
-    <ngds-text-input [control]="form?.controls?.['basicText']" [label]="'My input label'"
-      [subLabel]="'My input sub-label'" [placeholder]="'My placeholder'">
+  <demonstrator
+    [htmlFile]="snippets?.basicText?.html"
+    [tsFile]="snippets?.basicText?.ts"
+    [control]="form?.controls?.['basicText']"
+  >
+    <ngds-text-input
+      [control]="form?.controls?.['basicText']"
+      [label]="'My input label'"
+      [subLabel]="'My input sub-label'"
+      [placeholder]="'My placeholder'"
+    >
     </ngds-text-input>
   </demonstrator>
 </section>
 
-<section #section id="resetButton" class="mb-5 mt-3">
+<section
+  #section
+  id="resetButton"
+  class="mb-5 mt-3"
+>
   <h3>Reset button</h3>
   <p>
     Click on the <i class="b- bi-x-lg"></i> to reset this control. The <code>[resetButton]</code> attribute calls
     <code>control.reset()</code>.
   </p>
-  <demonstrator [htmlFile]="snippets?.resetInput?.html" [tsFile]="snippets?.resetInput?.ts"
-    [control]="form?.controls?.['resetInput']">
-    <ngds-text-input [control]="form?.controls?.['resetInput']" [resetButton]="true">
+  <demonstrator
+    [htmlFile]="snippets?.resetInput?.html"
+    [tsFile]="snippets?.resetInput?.ts"
+    [control]="form?.controls?.['resetInput']"
+  >
+    <ngds-text-input
+      [control]="form?.controls?.['resetInput']"
+      [resetButton]="true"
+    >
     </ngds-text-input>
   </demonstrator>
 </section>
 
-<section #section id="initialDefault" class="mb-5 mt-3">
+<section
+  #section
+  id="initialDefault"
+  class="mb-5 mt-3"
+>
   <h3>Initial default value</h3>
   <p>
     Resetting this control will reset it to its initial value of 'My default value'. You can set your custom default
@@ -39,158 +66,338 @@
     your initialization code, so that when <code>control.reset()</code> is called, it does not reset the value of the
     control to <code>null</code>.
   </p>
-  <demonstrator [htmlFile]="snippets?.initialDefault?.html" [tsFile]="snippets?.initialDefault?.ts"
-    [control]="form?.controls?.['initialDefault']">
-    <ngds-text-input [control]="form?.controls?.['initialDefault']" [resetButton]="true">
+  <demonstrator
+    [htmlFile]="snippets?.initialDefault?.html"
+    [tsFile]="snippets?.initialDefault?.ts"
+    [control]="form?.controls?.['initialDefault']"
+  >
+    <ngds-text-input
+      [control]="form?.controls?.['initialDefault']"
+      [resetButton]="true"
+    >
     </ngds-text-input>
   </demonstrator>
 </section>
 
-<section #section id="disabledInput" class="mb-5 mt-3">
+<section
+  #section
+  id="disabledInput"
+  class="mb-5 mt-3"
+>
   <h3>Disabled input</h3>
   <p>
     Use the toggle to enable/disable the control. You can use the <code>[disabled]</code> attribute to bind to a boolean
     or function that evaluates to a boolean. This will set the state of <code>control.enabled</code> and
     <code>control.disabled</code>.
   </p>
-  <demonstrator [htmlFile]="snippets?.disabledInput?.html" [tsFile]="snippets?.disabledInput?.ts"
-    [control]="form?.controls?.['disabledInput']">
-    <ngds-text-input [control]="form?.controls?.['disabledInput']" [resetButton]="true" [disabled]="isDisabled">
+  <demonstrator
+    [htmlFile]="snippets?.disabledInput?.html"
+    [tsFile]="snippets?.disabledInput?.ts"
+    [control]="form?.controls?.['disabledInput']"
+  >
+    <ngds-text-input
+      [control]="form?.controls?.['disabledInput']"
+      [resetButton]="true"
+      [disabled]="isDisabled"
+    >
     </ngds-text-input>
     <div class="form-check form-switch mt-2">
-      <input class="form-check-input" type="checkbox" id="flexSwitchDisabled" (click)="disabledSwitch()">
-      <label class="form-check-label" for="flexSwitchDisabled">Toggle disabled</label>
+      <input
+        class="form-check-input"
+        type="checkbox"
+        id="flexSwitchDisabled"
+        (click)="disabledSwitch()"
+      >
+      <label
+        class="form-check-label"
+        for="flexSwitchDisabled"
+      >Toggle disabled</label>
     </div>
     <div class="form-check form-switch mt-2">
-      <input class="form-check-input" type="checkbox" id="flexSwitchProgram"
-        [checked]="form?.controls?.['disabledInput'].disabled" (click)="disableProgrammatically('disabledInput')">
-      <label class="form-check-label" for="flexSwitchProgram">Toggle disable programmatically</label>
+      <input
+        class="form-check-input"
+        type="checkbox"
+        id="flexSwitchProgram"
+        [checked]="form?.controls?.['disabledInput'].disabled"
+        (click)="disableProgrammatically('disabledInput')"
+      >
+      <label
+        class="form-check-label"
+        for="flexSwitchProgram"
+      >Toggle disable programmatically</label>
     </div>
   </demonstrator>
 </section>
 
-<section #section id="loadingInput" class="mb-5 mt-3">
+<section
+  #section
+  id="loadingInput"
+  class="mb-5 mt-3"
+>
   <h3>Loading input</h3>
   <p>
     Use the toggle trigger the loading state of the control. You can use the <code>[loadWhile]</code> attribute to bind
     to a boolean or function that evaluates to a boolean. This will set the state of <code>control.enabled</code> and
     <code>control.disabled</code>. The loading state disables the control, and shows a loading spinner.
   </p>
-  <demonstrator [headerText]="'Loading spinner'" [htmlFile]="snippets?.loadingInput?.html"
+  <demonstrator
+    [headerText]="'Loading spinner'"
+    [htmlFile]="snippets?.loadingInput?.html"
     [tsFile]="snippets?.loadingInput?.ts"
     [description]="'Use the toggle trigger the loading state of the control. You can use the [loadWhile] attribute to bind to a boolean or function that evaluates to a boolean. The loading state disables the control, and shows a loading spinner.'"
-    [control]="form?.controls?.['loadingInput']">
-    <ngds-text-input [control]="form?.controls?.['loadingInput']" [resetButton]="true" [loadWhile]="isLoading">
+    [control]="form?.controls?.['loadingInput']"
+  >
+    <ngds-text-input
+      [control]="form?.controls?.['loadingInput']"
+      [resetButton]="true"
+      [loadWhile]="isLoading"
+    >
     </ngds-text-input>
     <div class="form-check form-switch mt-2">
-      <input class="form-check-input" type="checkbox" id="flexSwitchLoading" (click)="loadingSwitch()">
-      <label class="form-check-label" for="flexSwitchLoading">Toggle loading</label>
+      <input
+        class="form-check-input"
+        type="checkbox"
+        id="flexSwitchLoading"
+        (click)="loadingSwitch()"
+      >
+      <label
+        class="form-check-label"
+        for="flexSwitchLoading"
+      >Toggle loading</label>
     </div>
   </demonstrator>
 </section>
 
-<section #section id="multilineInput" class="mb-5 mt-3">
+<section
+  #section
+  id="multilineInput"
+  class="mb-5 mt-3"
+>
   <h3>Multiline text (textarea)</h3>
   <p>
-    Use <code>[multiline]="true"</code> to change the underlying HTML element from <code>input</code> to <code>textarea</code>. This enables multiline text entry. Set <code>[showCharacterCount]="true"</code> to see a character tally.
+    Use <code>[multiline]="true"</code> to change the underlying HTML element from <code>input</code> to
+    <code>textarea</code>. This enables multiline text entry. Set <code>[showCharacterCount]="true"</code> to see a
+    character tally.
   </p>
   <p>
-    Multiline text elements are compatible with Angular's providided <code>minLength</code> and <code>maxLength</code> validators.
+    Multiline text elements are compatible with Angular's providided <code>minLength</code> and <code>maxLength</code>
+    validators.
   </p>
-  <demonstrator [headerText]="'Loading spinner'" [htmlFile]="snippets?.multilineInput?.html"
+  <demonstrator
+    [headerText]="'Loading spinner'"
+    [htmlFile]="snippets?.multilineInput?.html"
     [tsFile]="snippets?.multilineInput?.ts"
     [description]="'Use the toggle trigger the loading state of the control. You can use the [loadWhile] attribute to bind to a boolean or function that evaluates to a boolean. The loading state disables the control, and shows a loading spinner.'"
-    [control]="form?.controls?.['multilineInput']">
-    <ngds-text-input [label]="'With showCharacterCount'" [control]="form?.controls?.['multilineInput']" [resetButton]="true" [loadWhile]="isLoading" [multiline]="true" [showCharacterCount]="true">
+    [control]="form?.controls?.['multilineInput']"
+  >
+    <ngds-text-input
+      [label]="'With showCharacterCount'"
+      [control]="form?.controls?.['multilineInput']"
+      [resetButton]="true"
+      [loadWhile]="isLoading"
+      [multiline]="true"
+      [showCharacterCount]="true"
+    >
     </ngds-text-input>
-    <ngds-text-input [label]="'With maxLength validator'" [subLabel]="'maxLength is 20'" [control]="form?.controls?.['multilineMaxInput']" [resetButton]="true" [loadWhile]="isLoading" [multiline]="true" [showCharacterCount]="true">
+    <ngds-text-input
+      [label]="'With maxLength validator'"
+      [subLabel]="'maxLength is 20'"
+      [control]="form?.controls?.['multilineMaxInput']"
+      [resetButton]="true"
+      [loadWhile]="isLoading"
+      [multiline]="true"
+      [showCharacterCount]="true"
+    >
     </ngds-text-input>
-    <ngds-text-input [label]="'With minLength validator'" [subLabel]="'minLength is 10'" [control]="form?.controls?.['multilineMinInput']" [resetButton]="true" [loadWhile]="isLoading" [multiline]="true" [showCharacterCount]="true">
+    <ngds-text-input
+      [label]="'With minLength validator'"
+      [subLabel]="'minLength is 10'"
+      [control]="form?.controls?.['multilineMinInput']"
+      [resetButton]="true"
+      [loadWhile]="isLoading"
+      [multiline]="true"
+      [showCharacterCount]="true"
+    >
     </ngds-text-input>
   </demonstrator>
 </section>
 
-<section #section id="requiredInput" class="mb-5 mt-3">
+<section
+  #section
+  id="requiredInput"
+  class="mb-5 mt-3"
+>
   <h3>Required input</h3>
   <p>
     NGDS forms use Angular Validators to determine control validity. This control is required. It will always be invalid
     if it is null or empty, but the invalid styling will not appear until it has been touched.
   </p>
-  <demonstrator [htmlFile]="snippets?.requiredInput?.html" [tsFile]="snippets?.requiredInput?.ts"
-    [control]="form?.controls?.['requiredInput']" >
+  <demonstrator
+    [htmlFile]="snippets?.requiredInput?.html"
+    [tsFile]="snippets?.requiredInput?.ts"
+    [control]="form?.controls?.['requiredInput']"
+  >
     <ngds-text-input [control]="form?.controls?.['requiredInput']">
     </ngds-text-input>
   </demonstrator>
 </section>
 
-<section #section id="hideInvalidState" class="mb-5 mt-3">
+<section
+  #section
+  id="hideInvalidState"
+  class="mb-5 mt-3"
+>
   <h3>Hide invalid state</h3>
   <p>
-    Set <code>[hideInvalidState]="true"</code> if you do not want to display a red border or error messages when the control is invalid. The field below is required, but no invalidation message shows.
+    Set <code>[hideInvalidState]="true"</code> if you do not want to display a red border or error messages when the
+    control is invalid. The field below is required, but no invalidation message shows.
   </p>
   <p>
-    You can also hide only the invalidation message but keep the red border and icon styling by using <code>[invalidConfig]</code> as explained in the <a href="/forms/text#customValidator">next</a> example.
+    You can also hide only the invalidation message but keep the red border and icon styling by using
+    <code>[invalidConfig]</code> as explained in the <a href="/forms/text#customValidator">next</a> example.
   </p>
-  <demonstrator [htmlFile]="snippets?.hideInvalidState?.html" [tsFile]="snippets?.hideInvalidState?.ts"
-    [control]="form?.controls?.['hideInvalidState']">
-    <ngds-text-input [control]="form?.controls?.['hideInvalidState']" [hideInvalidState]="true" >
+  <demonstrator
+    [htmlFile]="snippets?.hideInvalidState?.html"
+    [tsFile]="snippets?.hideInvalidState?.ts"
+    [control]="form?.controls?.['hideInvalidState']"
+  >
+    <ngds-text-input
+      [control]="form?.controls?.['hideInvalidState']"
+      [hideInvalidState]="true"
+    >
     </ngds-text-input>
   </demonstrator>
 </section>
 
-<section #section id="customValidator" class="mb-5 mt-3">
+<section
+  #section
+  id="customValidator"
+  class="mb-5 mt-3"
+>
   <h3>Custom validation</h3>
   <p>
     NGDS forms support custom validators. You can design your own custom validators using Angular's
-    <code>ValidationFn</code> in your components. This control will be invalid if its value is empty or 'invalid' is typed in.
+    <code>ValidationFn</code> in your components. This control will be invalid if its value is empty or 'invalid' is
+    typed in.
   </p>
   <p>You can customize the error message by using the <code>[invalidConfig]</code> directive.</p>
-  <demonstrator [htmlFile]="snippets?.customValidator?.html" [tsFile]="snippets?.customValidator?.ts"
-    [control]="form?.controls?.['customValidator']">
-    <ngds-text-input [control]="form?.controls?.['customValidator']" [invalidConfig]="invalidConfig">
+  <demonstrator
+    [htmlFile]="snippets?.customValidator?.html"
+    [tsFile]="snippets?.customValidator?.ts"
+    [control]="form?.controls?.['customValidator']"
+  >
+    <ngds-text-input
+      [control]="form?.controls?.['customValidator']"
+      [invalidConfig]="invalidConfig"
+    >
     </ngds-text-input>
   </demonstrator>
 </section>
 
-<section #section id="justification" class="mb-5 mt-3">
+<section
+  #section
+  id="justification"
+  class="mb-5 mt-3"
+>
   <h3>Justification</h3>
   <p>
-    The justification of some input types can be changed with <code>[justify]</code>, which uses the Bootstrap locations <code>start</code>, <code>end</code>, and <code>center</code> to justify the input value. Default is <code>start</code>.
+    The justification of some input types can be changed with <code>[justify]</code>, which uses the Bootstrap locations
+    <code>start</code>, <code>end</code>, and <code>center</code> to justify the input value. Default is
+    <code>start</code>.
   </p>
-  <demonstrator [htmlFile]="snippets?.justify?.html" [tsFile]="snippets?.justify?.ts"
-    [control]="form?.controls?.['justify']">
-    <ngds-text-input [control]="form?.controls?.['justify']"  [justify]="'end'">
+  <demonstrator
+    [htmlFile]="snippets?.justify?.html"
+    [tsFile]="snippets?.justify?.ts"
+    [control]="form?.controls?.['justify']"
+  >
+    <ngds-text-input
+      [control]="form?.controls?.['justify']"
+      [label]="'Right-justified'"
+      [justify]="'end'"
+    >
+    </ngds-text-input>
+    <ngds-text-input
+      [control]="form?.controls?.['justify']"
+      [label]="'Center-justified'"
+      [justify]="'center'"
+    >
     </ngds-text-input>
   </demonstrator>
 </section>
 
-<section #section id="inline" class="mb-5 mt-3">
+<section
+  #section
+  id="inline"
+  class="mb-5 mt-3"
+>
   <h3>Inline input items</h3>
   <p>
     Valid HTML can be rendered inline using the <code>ngdsInputPrepend</code> and <code>ngdsInputAppend</code>
     directives.
   </p>
-  <demonstrator [htmlFile]="snippets?.inline?.html"
-    [tsFile]="snippets?.inline?.ts" [cssFile]="snippets?.inline?.css"
-    [control]="form?.controls?.['inline']">
+  <demonstrator
+    [htmlFile]="snippets?.inline?.html"
+    [tsFile]="snippets?.inline?.ts"
+    [cssFile]="snippets?.inline?.css"
+    [control]="form?.controls?.['inline']"
+  >
     <h5>Buttons</h5>
-    <ngds-text-input [control]="form?.controls?.['inline']" [resetButton]="true">
-      <button ngdsInputPrepend class="btn btn-primary">Button 1</button>
-      <button ngdsInputPrepend class="btn btn-success">Button 2</button>
-      <button ngdsInputAppend class="btn btn-warning">Button 3</button>
-      <button ngdsInputAppend class="btn btn-danger">Button 4</button>
+    <ngds-text-input
+      [control]="form?.controls?.['inline']"
+      [resetButton]="true"
+    >
+      <button
+        ngdsInputPrepend
+        class="btn btn-primary"
+      >Button 1</button>
+      <button
+        ngdsInputPrepend
+        class="btn btn-success"
+      >Button 2</button>
+      <button
+        ngdsInputAppend
+        class="btn btn-warning"
+      >Button 3</button>
+      <button
+        ngdsInputAppend
+        class="btn btn-danger"
+      >Button 4</button>
     </ngds-text-input>
     <h5 class="mt-3">Icons</h5>
-    <ngds-text-input [control]="form?.controls?.['inline']" [resetButton]="true">
-      <i ngdsInputPrepend class="mx-2 align-items-center bi bi-info-circle"></i>
-      <i ngdsInputPrepend class="mx-2 bi bi-image-fill"></i>
-      <i ngdsInputAppend class="mx-2 bi bi-house"></i>
-      <i ngdsInputAppend class="mx-2 bi bi-link-45deg"></i>
+    <ngds-text-input
+      [control]="form?.controls?.['inline']"
+      [resetButton]="true"
+    >
+      <i
+        ngdsInputPrepend
+        class="mx-2 align-items-center bi bi-info-circle"
+      ></i>
+      <i
+        ngdsInputPrepend
+        class="mx-2 bi bi-image-fill"
+      ></i>
+      <i
+        ngdsInputAppend
+        class="mx-2 bi bi-house"
+      ></i>
+      <i
+        ngdsInputAppend
+        class="mx-2 bi bi-link-45deg"
+      ></i>
     </ngds-text-input>
     <h5 class="mt-3">Text</h5>
-    <ngds-text-input [control]="form?.controls?.['inline']" [resetButton]="true">
-      <div ngdsInputPrepend class="custom-prepend p-2 h-100 rounded-start">Prepended text with custom class</div>
-      <div ngdsInputAppend class="custom-append p-2 h-100 rounded-end">Appended text with custom class</div>
+    <ngds-text-input
+      [control]="form?.controls?.['inline']"
+      [resetButton]="true"
+    >
+      <div
+        ngdsInputPrepend
+        class="custom-prepend p-2 h-100 rounded-start"
+      >Prepended text with custom class</div>
+      <div
+        ngdsInputAppend
+        class="custom-append p-2 h-100 rounded-end"
+      >Appended text with custom class</div>
     </ngds-text-input>
   </demonstrator>
 </section>


### PR DESCRIPTION
Included in this PR:

 - Fixed a bug where when `loadWhile` switched from `true` to `false` (which occurs when something is finished loading), the field would enable regardless of whether or not there was another `disabled` state imposed on it. Field now checks other disabled states before enabling.
 - Fixed a bug for `number-input` where if the incrementer buttons or scroll wheel where used to change the value of the field to 0, the field value would instead be set to `null`. Field value now sets to zero.
 - Added a feature for `rangepicker` where you can now impose a minimum length of range to be selected.