### PR TITLE
Selectfirstonenter

### DIFF
--- a/projects/ngds-forms/assets/styles/styles.scss
+++ b/projects/ngds-forms/assets/styles/styles.scss
@@ -189,3 +189,7 @@ $active-invalid-outline: red;
 .closed-multiselect-input {
   width: 1%;
 }
+
+.active {
+  background-color: var(--bs-gray-500);
+}

--- a/projects/ngds-forms/src/lib/components/input-types/ngds-dropdown.component.ts
+++ b/projects/ngds-forms/src/lib/components/input-types/ngds-dropdown.component.ts
@@ -74,7 +74,21 @@ export class NgdsDropdown extends NgdsInput implements AfterViewInit {
       //   this.setFocusIndex(this.focusIndex, 1);
       // }
     }
-    // If the user presses the enter key, select the item that is currently focused
+    // If the user presses the enter key, highlight the item that is currently focused
+    if (this.isOpen && (event.key === 'Enter')) {
+      event.stopPropagation();
+      event.preventDefault();
+      let option = this.getOptionOnEnterPressed();
+      let focusedItem = this.getElementByValue(option?.value || option);
+      if (focusedItem) {
+        focusedItem.classList.add('active');
+      }
+    }
+  }
+
+  @HostListener('document:keyup', ['$event'])
+  handleKeyUpEvent(event: KeyboardEvent) {
+    // If the user releases the enter key, select the item that is currently focused
     if (this.isOpen && (event.key === 'Enter')) {
       event.stopPropagation();
       event.preventDefault();
@@ -237,6 +251,19 @@ export class NgdsDropdown extends NgdsInput implements AfterViewInit {
     }
   }
 
+  getElementByValue(value) {
+    if (this.dropdownMenu && this.dropdownMenu.nativeElement) {
+      let menuElements = this.dropdownMenu.nativeElement.querySelectorAll('[type="menuitem"]');
+      for (let i = 0; i < menuElements.length; i++) {
+        let element = menuElements[i];
+        if (element?.attributes?.value?.value === value || element?.innerText === value) {
+          return element;
+        }
+      }
+    }
+    return null;
+  }
+
   getOptionOnEnterPressed() {
     let option = this.getFocusedItemValue();
     if (option) {
@@ -251,7 +278,7 @@ export class NgdsDropdown extends NgdsInput implements AfterViewInit {
     const menu = this.dropdownMenu.nativeElement;
     if (menu) {
       const focusedItem = menu?.querySelector(':focus');
-      return focusedItem
+      return focusedItem;
     }
     return null;
   }

--- a/projects/ngds-forms/src/lib/components/input-types/picklist-input/picklist-input.component.html
+++ b/projects/ngds-forms/src/lib/components/input-types/picklist-input/picklist-input.component.html
@@ -117,7 +117,7 @@
     </li>
     <li
       *ngFor="let option of displayedSelectionListItems;"
-      role="menuitem"
+      type="menuitem"
       class="option-item"
       href="#"
     >

--- a/projects/ngds-forms/src/lib/components/input-types/typeahead-input/typeahead-input.component.html
+++ b/projects/ngds-forms/src/lib/components/input-types/typeahead-input/typeahead-input.component.html
@@ -69,7 +69,7 @@
         style="max-height: 250px; overflow-y: auto; min-width: 400px"
       >
         <ng-content
-          *ngTemplateOutlet="getTemplate(); context: {matches: refinedListItems, items: displayedSelectionListItems, query: currentDisplay }"
+          *ngTemplateOutlet="getTemplate(); context: {matches: refinedListItems, items: displayedSelectionListItems, query: currentDisplay, control: control }"
         ></ng-content>
       </ul>
     </div>
@@ -136,9 +136,11 @@
     [class.focused]="checkFocusIndex(match)"
     (mouseenter)="setFocusIndex(matches.indexOf(match))"
     (click)="selected(match)"
-    [ngClass]="{'active': match.value === control?.value}"
+    [class.active]="match?.value === control?.value"
+    aria-current="match?.value === control?.value"
+    href="#"
     type="menuitem"
-    value="{{ match?.value || match}}"
+    [value]="match?.value || match"
     [disabled]="match?.disabled"
   >
     <div [innerHtml]="match?.innerHtml"></div>

--- a/projects/ngds-forms/src/lib/components/input-types/typeahead-input/typeahead-input.component.ts
+++ b/projects/ngds-forms/src/lib/components/input-types/typeahead-input/typeahead-input.component.ts
@@ -1,4 +1,4 @@
-import { AfterViewInit, ChangeDetectorRef, Component, ElementRef, HostListener, Input, Renderer2, TemplateRef, ViewChild } from '@angular/core';
+import { AfterViewInit, ChangeDetectorRef, Component, Input, Renderer2 } from '@angular/core';
 import { NgdsDropdown } from '../ngds-dropdown.component';
 
 @Component({

--- a/src/app/forms/typeaheads/typeahead-snippets.ts
+++ b/src/app/forms/typeaheads/typeahead-snippets.ts
@@ -804,5 +804,85 @@ export const snippets = {
           })
         }
 `
+  },
+  selectFirstOnEnterTypeahead: {
+    html: `
+    <ngds-typeahead-input
+      [control]="form?.controls?.['selectFirstOnEnterTypeahead']"
+      [selectionListItems]="displayProvinceList"
+      [placeholder]="'Start typing...'"
+      [selectFirstItemOnEnter]="false"
+      [resetButton]="true">
+    </ngds-typeahead-input>`,
+    ts: `
+    import { Component } from '@angular/core';
+    import { UntypedFormControl, UntypedFormGroup} from '@angular/forms';
+
+    @Component({
+      selector: 'select-first-typeahead'
+      export class SelectFirstTypeahead implements OnInit {
+        public form;
+
+        displayProvinceList = [
+          {
+            value: '0001',
+            display: 'British Columbia'
+          },
+          {
+            value: '0002',
+            display: 'Alberta'
+          },
+          {
+            value: '0003',
+            display: 'Saskatchewan'
+          },
+          {
+            value: '0004',
+            display: 'Manitoba'
+          },
+          {
+            value: '0005',
+            display: 'Ontario'
+          },
+          {
+            value: '0006',
+            display: 'Quebec'
+          },
+          {
+            value: '0007',
+            display: 'Nova Scotia'
+          },
+          {
+            value: '0008',
+            display: 'Newfoundland and Labrador'
+          },
+          {
+            value: '0009',
+            display: 'New Brunswick'
+          },
+          {
+            value: '0010',
+            display: 'Prince Edward Island'
+          },
+          {
+            value: '0011',
+            display: 'Yukon'
+          },
+          {
+            value: '0012',
+            display: 'Northwest Territories'
+          },
+          {
+            value: '0013',
+            display: 'Nunavut'
+          },
+        ]
+
+        ngOnInit(): void {
+          this.form = new UntypedFormGroup({
+            selectFirstOnEnterTypeahead: new UntypedFormControl(null),
+          })
+        }
+`
   }
 }

--- a/src/app/forms/typeaheads/typeaheads.component.html
+++ b/src/app/forms/typeaheads/typeaheads.component.html
@@ -241,6 +241,37 @@
   </demonstrator>
 </section>
 
+<section
+  #section
+  id="selectFirstItemTypeahead"
+  class="mb-5 mt-3"
+>
+  <h3>Select first item on enter pressed</h3>
+  <p>
+    By default, if the typeahead or picklist dropdown is open and the user has not already tabbed to a particular
+    option, the typeahead will select the first item in the list when the user presses enter. If the user has started
+    typing, the first item that matches the typeahead query will be selected. This behaviour can be
+    disabled by setting <code>[selectFirstItemOnEnter]="false"</code> on the input.
+  </p>
+  <p>
+    In the example below, the behaviour is disabled, so pressing enter will not select the first item in the list.
+  </p>
+  <demonstrator
+    [htmlFile]="snippets?.selectFirstOnEnterTypeahead?.html"
+    [tsFile]="snippets?.selectFirstOnEnterTypeahead?.ts"
+    [control]="form?.controls?.['selectFirstOnEnterTypeahead']"
+  >
+    <ngds-typeahead-input
+      [control]="form?.controls?.['selectFirstOnEnterTypeahead']"
+      [selectionListItems]="displayProvinceList"
+      [selectFirstItemOnEnter]="false"
+      [placeholder]="'Start typing...'"
+      [resetButton]="true"
+    >
+    </ngds-typeahead-input>
+  </demonstrator>
+</section>
+
 <!-- <section
   #section
   id="displaySelectedTypeahead"

--- a/src/app/forms/typeaheads/typeaheads.component.ts
+++ b/src/app/forms/typeaheads/typeaheads.component.ts
@@ -114,6 +114,7 @@ export class TypeaheadsComponent implements OnInit {
         disableTypeahead: new UntypedFormControl(''),
         invalidTypeahead: new UntypedFormControl('', [this.customValidator()]),
         displaySelectedTypeahead: new UntypedFormControl(''),
+        selectFirstOnEnterTypeahead: new UntypedFormControl(''),
       }
     )
     for (const control of Object.keys(this.form.controls)) {


### PR DESCRIPTION
Adding the optional `[selectFirstItemOnEnter]` argument, which is default set to `true`. When the enter key is pressed, either the item currently focused in the dropdown is highlighted, or, if no option is focused, the first item in the dropdown is highlighted. When enter is released, the highlighted item is selected. 