### PR TITLE
fix(facility): set disablePast to true on date input

### DIFF
--- a/projects/ngds-forms/src/lib/components/input-types/date-input/calendar/calendar-manager/calendar-manager.component.html
+++ b/projects/ngds-forms/src/lib/components/input-types/date-input/calendar/calendar-manager/calendar-manager.component.html
@@ -18,6 +18,7 @@
       (changeHoverDate)="updateHoverDate($event)"
       (changeDisplay)="changeDisplayByValue($event)"
       (clearDates)="clearDates.emit()"
+      [disablePast]="disablePast"
     ></ngds-calendar>
   </div>
   <div
@@ -42,6 +43,7 @@
       (changeHoverDate)="updateHoverDate($event)"
       (changeDisplay)="changeDisplayByValue($event)"
       (clearDates)="clearDates.emit()"
+      [disablePast]="disablePast"
     ></ngds-calendar>
   </div>
 </div>

--- a/projects/ngds-forms/src/lib/components/input-types/date-input/calendar/calendar-manager/calendar-manager.component.ts
+++ b/projects/ngds-forms/src/lib/components/input-types/date-input/calendar/calendar-manager/calendar-manager.component.ts
@@ -66,6 +66,9 @@ export class NgdsCalendarManager implements OnInit, AfterViewInit {
   // Whether or not to show just one calendar in the rangepicker
   @Input() hideSecondCalendar: boolean = false;
 
+  // When true, disables past months/years in grids and blocks backward navigation.
+  @Input() disablePast: boolean = false;
+
   // Emits when a selected date is changed.
   @Output() dateChange = new EventEmitter;
 

--- a/projects/ngds-forms/src/lib/components/input-types/date-input/calendar/calendar/calendar.component.html
+++ b/projects/ngds-forms/src/lib/components/input-types/date-input/calendar/calendar/calendar.component.html
@@ -18,7 +18,7 @@
       </div>
       <div class="d-flex row">
         <div class="col">
-          <button class="btn btn-outline-secondary border-0" (click)="changeDisplay.emit(-1)" [disabled]="disabled" aria-label="previous calendar">
+          <button class="btn btn-outline-secondary border-0" (click)="changeDisplay.emit(-1)" [disabled]="disabled || isPrevNavDisabled()" aria-label="previous calendar">
             <i class="bi bi-chevron-left"></i>
           </button>
         </div>

--- a/projects/ngds-forms/src/lib/components/input-types/date-input/calendar/calendar/calendar.component.ts
+++ b/projects/ngds-forms/src/lib/components/input-types/date-input/calendar/calendar/calendar.component.ts
@@ -40,6 +40,9 @@ export class NgdsCalendar implements OnInit {
   // Whether or not to allow rangepickers to have disabled dates within the ranges they select.
   @Input() allowDisabledInRange: boolean = false;
 
+  // When true, disables past months/years in grids and blocks backward navigation.
+  @Input() disablePast: boolean = false;
+
   // OUTPUTS:
   // Emits when the selected date is changed.
   @Output() changeDate = new EventEmitter;
@@ -261,7 +264,7 @@ export class NgdsCalendar implements OnInit {
    */
   getMonthClasses(month) {
     let classes = ['btn', 'w-100', 'calendar-month'];
-    if (this.minDisplayDepth === 1 && this.checkDisabledMonth(month)) {
+    if ((this.minDisplayDepth === 1 || this.disablePast) && this.checkDisabledMonth(month)) {
       return classes;
     }
     if (this.checkMonth(month, this.calendarConfig.value.year)) {
@@ -277,13 +280,32 @@ export class NgdsCalendar implements OnInit {
    */
   getYearClasses(year) {
     let classes = ['btn', 'w-100', 'calendar-month'];
-    if (this.minDisplayDepth === 2 && this.checkDisabledMonth(year)) {
+    if ((this.minDisplayDepth === 2 || this.disablePast) && this.checkDisabledYear(year)) {
       return classes;
     }
     if (this.checkYear(year)) {
       classes.push('selected');
     }
     return classes;
+  }
+
+  /**
+   * Returns true when the backward navigation arrow should be disabled.
+   * Only active when disablePast is true.
+   */
+  isPrevNavDisabled(): boolean {
+    if (!this.disablePast) return false;
+    const now = DateTime.now();
+    const cal = this.calendarConfig?.value;
+    switch (this.depth) {
+      case 2:
+        return (cal?.years?.flat()[0] ?? 0) <= now.year;
+      case 1:
+        return (cal?.year ?? 0) <= now.year;
+      default:
+        return cal?.date?.year < now.year ||
+          (cal?.date?.year === now.year && cal?.date?.month <= now.month);
+    }
   }
 
   /**
@@ -393,6 +415,13 @@ export class NgdsCalendar implements OnInit {
    * @returns boolean - is the provided month disabled
    */
   checkDisabledMonth(month) {
+    if (this.disablePast) {
+      const now = DateTime.now();
+      const year = this.calendarConfig.value.year;
+      if (year < now.year || (year === now.year && month.number < now.month)) {
+        return true;
+      }
+    }
     if (this.minDisplayDepth === 0) {
       return false;
     }
@@ -407,6 +436,9 @@ export class NgdsCalendar implements OnInit {
    * @returns boolean - is the provided year disabled
    */
   checkDisabledYear(year) {
+    if (this.disablePast && year < DateTime.now().year) {
+      return true;
+    }
     if (this.minDisplayDepth <= 1) {
       return false;
     }

--- a/projects/ngds-forms/src/lib/components/input-types/date-input/date-input.component.html
+++ b/projects/ngds-forms/src/lib/components/input-types/date-input/date-input.component.html
@@ -109,6 +109,7 @@
     [selectedEndDate]="selectedEndDate.value"
     [allowDisabledInRange]="allowDisabledInRange"
     [hideSecondCalendar]="hideSecondCalendar"
+    [disablePast]="disablePast"
   >
   </ngds-calendar-manager>
 </ng-template>

--- a/projects/ngds-forms/src/lib/components/input-types/date-input/date-input.component.ts
+++ b/projects/ngds-forms/src/lib/components/input-types/date-input/date-input.component.ts
@@ -59,6 +59,10 @@ export class NgdsDateInput extends NgdsDropdown {
   // Fixed range to select when picking date. When a start date is selected, the endDate will automatically be set.
   @Input() fixedRangeSize: Duration;
 
+  // When true, disables past months and years in the month/year grids and blocks backward navigation.
+  // Intended for public-facing pickers; leave unset (false) for admin pickers that need past dates.
+  @Input() disablePast: boolean = false;
+
   // Emits when the display changes.
   @Output() displayChange = new EventEmitter;
 


### PR DESCRIPTION
### Ticket 
https://github.com/bcgov/reserve-rec-public/issues/638

### Description 
On the public side we want to disable past year because users are only allowed to book future dates, so showing past dates is not good UI. the change only needs to happen on public side. so we can use this option to disable.

Summary of changes:

- date-input.component.ts — @Input() disablePast: boolean = false
- date-input.component.html — passes [disablePast] to ngds-calendar-manager
- calendar-manager.component.ts — @Input() disablePast, passed to both calendar instances
- calendar-manager.component.html — [disablePast] on both <ngds-calendar> tags
- calendar.component.ts — @Input() disablePast; isPrevNavDisabled() blocks backward nav arrow in date/month/year modes;
checkDisabledMonth and checkDisabledYear disable past cells; getMonthClasses/getYearClasses apply disabled styling
- calendar.component.html — prev arrow gets || isPrevNavDisabled()